### PR TITLE
Add clang-tidy config and precommit db

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,15 @@
+---
+Checks: '-*'
+  ,clang-analyzer-* 
+  ,modernize-* 
+  ,performance-* 
+  ,readability-* 
+  ,bugprone-* 
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+AnalyzeTemporaryDtors: false
+FormatStyle: file
+ExtraArgs:
+  - -std=c23
+  - -std=c++17
+...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,13 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.5
+    hooks:
+      - id: clang-format
+        files: \.(c|cpp|h|hpp)$
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: v0.1.1
+    hooks:
+      - id: clang-tidy
+        files: \.(c|cpp|h|hpp)$


### PR DESCRIPTION
## Summary
- add minimal `.clang-tidy` to support C23 and C++17 builds
- update `.pre-commit-config.yaml` to include clang-format and clang-tidy hooks
- create `.pre-commit` directory to act as a pre-commit cache home

## Testing
- `pre-commit --version` *(fails: command not found)*