### PR TITLE
Refactor acd modernization into small modules

### DIFF
--- a/modern/Makefile
+++ b/modern/Makefile
@@ -1,13 +1,14 @@
-CC_32 = gcc -m32 -std=c23 -Wall -Wextra -pedantic
-CC_64 = gcc -m64 -std=c23 -Wall -Wextra -pedantic
+CC_32 = gcc -m32 -std=c2x -Wall -Wextra -pedantic
+CC_64 = gcc -m64 -std=c2x -Wall -Wextra -pedantic
+SRC = acd_c23.c args.c
 
 all: acd32 acd64
 
-acd32: acd_c23.c
-$(CC_32) $< -o $@
+acd32: $(SRC)
+	$(CC_32) $(SRC) -o $@
 
-acd64: acd_c23.c
-$(CC_64) $< -o $@
+acd64: $(SRC)
+	$(CC_64) $(SRC) -o $@
 
 clean:
-rm -f acd32 acd64
+	rm -f acd32 acd64

--- a/modern/README.md
+++ b/modern/README.md
@@ -5,6 +5,11 @@ Harvey OS utilities into standard C23. The goal is to eventually build
 portable versions that target both 32‑bit and 64‑bit x86 systems without
 relying on the original Plan 9 libraries.
 
-Currently the implementation only provides a small skeleton for the
-`acd` CD‑player tool. The code is not feature complete and serves merely as a
-starting point for future modernization efforts.
+The first utility under modernization is `acd`. The code has been split into
+small modules to ease future development:
+
+* `msf.h` – helper for dealing with CD minute/second/frame values.
+* `args.c`/`args.h` – minimal command line parsing.
+* `acd_c23.c` – main entry point demonstrating the modernized skeleton.
+
+Run `make` in this directory to build both 32‑bit and 64‑bit binaries.

--- a/modern/acd_c23.c
+++ b/modern/acd_c23.c
@@ -1,40 +1,16 @@
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
 #include <stdbool.h>
-
-/* Minute, second, frame structure used in the original acd code. */
-typedef struct {
-    int m;
-    int s;
-    int f;
-} Msf;
-
-static void usage(void) {
-    fputs("usage: acd <device>\n", stderr);
-    exit(EXIT_FAILURE);
-}
+#include "msf.h"
+#include "args.h"
 
 int main(int argc, char **argv) {
-    bool verbose = false;
-    const char *device = NULL;
+    CmdArgs args = parse_args(argc, argv);
+    printf("C23 acd skeleton running on device %s. Verbose=%d\n",
+           args.device, args.verbose);
 
-    for (int i = 1; i < argc; ++i) {
-        if (strcmp(argv[i], "-v") == 0) {
-            verbose = true;
-        } else if (!device) {
-            device = argv[i];
-        } else {
-            usage();
-        }
-    }
-
-    if (!device)
-        usage();
-
-    printf("C23 acd skeleton running on device %s. Verbose=%d\n", device, verbose);
     /* TODO: implement SCSI access and event loop using pthreads. */
+    Msf start = msf_from_frames(0);
+    printf("Start at %02d:%02d.%02d\n", start.m, start.s, start.f);
 
     return 0;
 }

--- a/modern/args.c
+++ b/modern/args.c
@@ -1,0 +1,25 @@
+#include "args.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void usage(void) {
+    fputs("usage: acd [-v] <device>\n", stderr);
+    exit(EXIT_FAILURE);
+}
+
+CmdArgs parse_args(int argc, char **argv) {
+    CmdArgs args = {0};
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "-v") == 0) {
+            args.verbose = true;
+        } else if (!args.device) {
+            args.device = argv[i];
+        } else {
+            usage();
+        }
+    }
+    if (!args.device)
+        usage();
+    return args;
+}

--- a/modern/args.h
+++ b/modern/args.h
@@ -1,0 +1,13 @@
+#ifndef HARVEY_ARGS_H
+#define HARVEY_ARGS_H
+
+#include <stdbool.h>
+
+typedef struct {
+    bool verbose;
+    const char *device;
+} CmdArgs;
+
+CmdArgs parse_args(int argc, char **argv);
+
+#endif /* HARVEY_ARGS_H */

--- a/modern/msf.h
+++ b/modern/msf.h
@@ -1,0 +1,22 @@
+#ifndef HARVEY_MSF_H
+#define HARVEY_MSF_H
+
+#include <stdint.h>
+
+/* Minute, second, frame structure from original acd code */
+typedef struct {
+    int m;
+    int s;
+    int f;
+} Msf;
+
+static inline Msf msf_from_frames(uint32_t frames) {
+    Msf msf;
+    msf.m = frames / (60 * 75);
+    frames %= 60 * 75;
+    msf.s = frames / 75;
+    msf.f = frames % 75;
+    return msf;
+}
+
+#endif /* HARVEY_MSF_H */


### PR DESCRIPTION
## Summary
- restructure modern `acd` skeleton
- add `args` module for argument parsing and `msf` helper
- update Makefile to build using both modules
- document the new layout

## Testing
- `make -C modern acd64`
- ❌ `pre-commit` *(fails: command not found)*