### PR TITLE
Enable clang-format and C23

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: false

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: llvm/clang-format@v1
+        with:
+          style: file
+          path: "**/*.{c,h}"
+      - run: make all CFLAGS+=' -std=c23 -Wall -Wextra -Wpedantic -Werror'
+      - run: clang-tidy --config-file=clang-tidy.config $(find . -name '*.c' -o -name '*.h') -- -std=c23

--- a/386/include/ape/float.h
+++ b/386/include/ape/float.h
@@ -2,72 +2,71 @@
 #define __FLOAT
 /* IEEE, default rounding */
 
-#define FLT_ROUNDS	1
-#define FLT_RADIX	2
+#define FLT_ROUNDS 1
+#define FLT_RADIX 2
 
-#define FLT_DIG		6
-#define FLT_EPSILON	1.19209290e-07
-#define FLT_MANT_DIG	24
-#define FLT_MAX		3.40282347e+38
-#define FLT_MAX_10_EXP	38
-#define FLT_MAX_EXP	128
-#define FLT_MIN		1.17549435e-38
-#define FLT_MIN_10_EXP	-37
-#define FLT_MIN_EXP	-125
+#define FLT_DIG 6
+#define FLT_EPSILON 1.19209290e-07
+#define FLT_MANT_DIG 24
+#define FLT_MAX 3.40282347e+38
+#define FLT_MAX_10_EXP 38
+#define FLT_MAX_EXP 128
+#define FLT_MIN 1.17549435e-38
+#define FLT_MIN_10_EXP -37
+#define FLT_MIN_EXP -125
 
-#define DBL_DIG		15
-#define DBL_EPSILON	2.2204460492503131e-16
-#define DBL_MANT_DIG	53
-#define DBL_MAX		1.797693134862315708145e+308
-#define DBL_MAX_10_EXP	308
-#define DBL_MAX_EXP	1024
-#define DBL_MIN		2.225073858507201383090233e-308
-#define DBL_MIN_10_EXP	-307
-#define DBL_MIN_EXP	-1021
-#define LDBL_MANT_DIG	DBL_MANT_DIG
-#define LDBL_EPSILON	DBL_EPSILON
-#define LDBL_DIG	DBL_DIG
-#define LDBL_MIN_EXP	DBL_MIN_EXP
-#define LDBL_MIN	DBL_MIN
-#define LDBL_MIN_10_EXP	DBL_MIN_10_EXP
-#define LDBL_MAX_EXP	DBL_MAX_EXP
-#define LDBL_MAX	DBL_MAX
-#define LDBL_MAX_10_EXP	DBL_MAX_10_EXP
+#define DBL_DIG 15
+#define DBL_EPSILON 2.2204460492503131e-16
+#define DBL_MANT_DIG 53
+#define DBL_MAX 1.797693134862315708145e+308
+#define DBL_MAX_10_EXP 308
+#define DBL_MAX_EXP 1024
+#define DBL_MIN 2.225073858507201383090233e-308
+#define DBL_MIN_10_EXP -307
+#define DBL_MIN_EXP -1021
+#define LDBL_MANT_DIG DBL_MANT_DIG
+#define LDBL_EPSILON DBL_EPSILON
+#define LDBL_DIG DBL_DIG
+#define LDBL_MIN_EXP DBL_MIN_EXP
+#define LDBL_MIN DBL_MIN
+#define LDBL_MIN_10_EXP DBL_MIN_10_EXP
+#define LDBL_MAX_EXP DBL_MAX_EXP
+#define LDBL_MAX DBL_MAX
+#define LDBL_MAX_10_EXP DBL_MAX_10_EXP
 
-typedef 	union FPdbleword FPdbleword;
-union FPdbleword
-{
-	double	x;
-	struct {	/* little endian */
-		long lo;
-		long hi;
-	};
+typedef union FPdbleword FPdbleword;
+union FPdbleword {
+    double x;
+    struct { /* little endian */
+        long lo;
+        long hi;
+    };
 };
 
 #ifdef _RESEARCH_SOURCE
 /* define stuff needed for floating conversion */
-#define IEEE_8087	1
+#define IEEE_8087 1
 #define Sudden_Underflow 1
 #endif
 #ifdef _PLAN9_SOURCE
 /* FCR */
-#define	FPINEX	(1<<5)
-#define	FPOVFL	(1<<3)
-#define	FPUNFL	((1<<4)|(1<<1))
-#define	FPZDIV	(1<<2)
-#define	FPRNR	(0<<10)
-#define	FPRZ	(3<<10)
-#define	FPRPINF	(2<<10)
-#define	FPRNINF	(1<<10)
-#define	FPRMASK	(3<<10)
-#define	FPPEXT	(3<<8)
-#define	FPPSGL	(0<<8)
-#define	FPPDBL	(2<<8)
-#define	FPPMASK	(3<<8)
+#define FPINEX (1 << 5)
+#define FPOVFL (1 << 3)
+#define FPUNFL ((1 << 4) | (1 << 1))
+#define FPZDIV (1 << 2)
+#define FPRNR (0 << 10)
+#define FPRZ (3 << 10)
+#define FPRPINF (2 << 10)
+#define FPRNINF (1 << 10)
+#define FPRMASK (3 << 10)
+#define FPPEXT (3 << 8)
+#define FPPSGL (0 << 8)
+#define FPPDBL (2 << 8)
+#define FPPMASK (3 << 8)
 /* FSR */
-#define	FPAINEX	FPINEX
-#define	FPAOVFL	FPOVFL
-#define	FPAUNFL	FPUNFL
-#define	FPAZDIV	FPZDIV
+#define FPAINEX FPINEX
+#define FPAOVFL FPOVFL
+#define FPAUNFL FPUNFL
+#define FPAZDIV FPZDIV
 #endif
 #endif /* __FLOAT */

--- a/386/include/ape/math.h
+++ b/386/include/ape/math.h
@@ -41,19 +41,19 @@ extern int isInf(double, int);
 #ifdef _RESEARCH_SOURCE
 /* does >> treat left operand as unsigned ? */
 #define Unsigned_Shifts 1
-#define	M_E		2.7182818284590452354	/* e */
-#define	M_LOG2E		1.4426950408889634074	/* log 2e */
-#define	M_LOG10E	0.43429448190325182765	/* log 10e */
-#define	M_LN2		0.69314718055994530942	/* log e2 */
-#define	M_LN10		2.30258509299404568402	/* log e10 */
-#define	M_PI		3.14159265358979323846	/* pi */
-#define	M_PI_2		1.57079632679489661923	/* pi/2 */
-#define	M_PI_4		0.78539816339744830962	/* pi/4 */
-#define	M_1_PI		0.31830988618379067154	/* 1/pi */
-#define	M_2_PI		0.63661977236758134308	/* 2/pi */
-#define	M_2_SQRTPI	1.12837916709551257390	/* 2/sqrt(pi) */
-#define	M_SQRT2		1.41421356237309504880	/* sqrt(2) */
-#define	M_SQRT1_2	0.70710678118654752440	/* 1/sqrt(2) */
+#define M_E 2.7182818284590452354         /* e */
+#define M_LOG2E 1.4426950408889634074     /* log 2e */
+#define M_LOG10E 0.43429448190325182765   /* log 10e */
+#define M_LN2 0.69314718055994530942      /* log e2 */
+#define M_LN10 2.30258509299404568402     /* log e10 */
+#define M_PI 3.14159265358979323846       /* pi */
+#define M_PI_2 1.57079632679489661923     /* pi/2 */
+#define M_PI_4 0.78539816339744830962     /* pi/4 */
+#define M_1_PI 0.31830988618379067154     /* 1/pi */
+#define M_2_PI 0.63661977236758134308     /* 2/pi */
+#define M_2_SQRTPI 1.12837916709551257390 /* 2/sqrt(pi) */
+#define M_SQRT2 1.41421356237309504880    /* sqrt(2) */
+#define M_SQRT1_2 0.70710678118654752440  /* 1/sqrt(2) */
 
 extern double hypot(double, double);
 extern double erf(double);
@@ -66,7 +66,6 @@ extern double jn(int, double);
 extern double yn(int, double);
 
 #endif
-
 
 #ifdef __cplusplus
 }

--- a/386/include/ape/stdarg.h
+++ b/386/include/ape/stdarg.h
@@ -3,14 +3,12 @@
 
 typedef char *va_list;
 
-#define va_start(list, start) list = (sizeof(start)<4 ? (char *)((int *)&(start)+1) : \
-(char *)(&(start)+1))
+#define va_start(list, start)                                                                      \
+    list = (sizeof(start) < 4 ? (char *)((int *)&(start) + 1) : (char *)(&(start) + 1))
 #define va_end(list)
-#define va_arg(list, mode)\
-	((sizeof(mode) == 1)?\
-		((list += 4), (mode*)list)[-4]:\
-	(sizeof(mode) == 2)?\
-		((list += 4), (mode*)list)[-2]:\
-		((list += sizeof(mode)), (mode*)list)[-1])
+#define va_arg(list, mode)                                                                         \
+    ((sizeof(mode) == 1)   ? ((list += 4), (mode *)list)[-4]                                       \
+     : (sizeof(mode) == 2) ? ((list += 4), (mode *)list)[-2]                                       \
+                           : ((list += sizeof(mode)), (mode *)list)[-1])
 
 #endif /* __STDARG */

--- a/386/include/ape/ureg.h
+++ b/386/include/ape/ureg.h
@@ -1,33 +1,32 @@
 #ifndef __UREG_H
 #define __UREG_H
 #if !defined(_PLAN9_SOURCE)
-    This header file is an extension to ANSI/POSIX
+This header file is an extension to ANSI / POSIX
 #endif
 
-struct Ureg
-{
-	unsigned long	di;		/* general registers */
-	unsigned long	si;		/* ... */
-	unsigned long	bp;		/* ... */
-	unsigned long	nsp;
-	unsigned long	bx;		/* ... */
-	unsigned long	dx;		/* ... */
-	unsigned long	cx;		/* ... */
-	unsigned long	ax;		/* ... */
-	unsigned long	gs;		/* data segments */
-	unsigned long	fs;		/* ... */
-	unsigned long	es;		/* ... */
-	unsigned long	ds;		/* ... */
-	unsigned long	trap;		/* trap type */
-	unsigned long	ecode;		/* error code (or zero) */
-	unsigned long	pc;		/* pc */
-	unsigned long	cs;		/* old context */
-	unsigned long	flags;		/* old flags */
-	union {
-		unsigned long	usp;
-		unsigned long	sp;
-	};
-	unsigned long	ss;		/* old stack segment */
+    struct Ureg {
+    unsigned long di; /* general registers */
+    unsigned long si; /* ... */
+    unsigned long bp; /* ... */
+    unsigned long nsp;
+    unsigned long bx;    /* ... */
+    unsigned long dx;    /* ... */
+    unsigned long cx;    /* ... */
+    unsigned long ax;    /* ... */
+    unsigned long gs;    /* data segments */
+    unsigned long fs;    /* ... */
+    unsigned long es;    /* ... */
+    unsigned long ds;    /* ... */
+    unsigned long trap;  /* trap type */
+    unsigned long ecode; /* error code (or zero) */
+    unsigned long pc;    /* pc */
+    unsigned long cs;    /* old context */
+    unsigned long flags; /* old flags */
+    union {
+        unsigned long usp;
+        unsigned long sp;
+    };
+    unsigned long ss; /* old stack segment */
 };
 
 #endif

--- a/386/include/u.h
+++ b/386/include/u.h
@@ -1,65 +1,59 @@
-#define nil		((void*)0)
-typedef	unsigned short	ushort;
-typedef	unsigned char	uchar;
-typedef unsigned long	ulong;
-typedef unsigned int	uint;
-typedef   signed char	schar;
-typedef	long long	vlong;
-typedef	unsigned long long uvlong;
-typedef unsigned long	uintptr;
-typedef unsigned long	usize;
-typedef	uint		Rune;
+#define nil ((void *)0)
+typedef unsigned short ushort;
+typedef unsigned char uchar;
+typedef unsigned long ulong;
+typedef unsigned int uint;
+typedef signed char schar;
+typedef long long vlong;
+typedef unsigned long long uvlong;
+typedef unsigned long uintptr;
+typedef unsigned long usize;
+typedef uint Rune;
 typedef union FPdbleword FPdbleword;
-typedef long		jmp_buf[2];
-#define	JMPBUFSP	0
-#define	JMPBUFPC	1
-#define	JMPBUFDPC	0
-typedef unsigned int	mpdigit;	/* for /sys/include/mp.h */
-typedef unsigned char	u8int;
-typedef unsigned short	u16int;
-typedef unsigned int	u32int;
+typedef long jmp_buf[2];
+#define JMPBUFSP 0
+#define JMPBUFPC 1
+#define JMPBUFDPC 0
+typedef unsigned int mpdigit; /* for /sys/include/mp.h */
+typedef unsigned char u8int;
+typedef unsigned short u16int;
+typedef unsigned int u32int;
 typedef unsigned long long u64int;
 
 /* FCR */
-#define	FPINEX	(1<<5)
-#define	FPUNFL	((1<<4)|(1<<1))
-#define	FPOVFL	(1<<3)
-#define	FPZDIV	(1<<2)
-#define	FPINVAL	(1<<0)
-#define	FPRNR	(0<<10)
-#define	FPRZ	(3<<10)
-#define	FPRPINF	(2<<10)
-#define	FPRNINF	(1<<10)
-#define	FPRMASK	(3<<10)
-#define	FPPEXT	(3<<8)
-#define	FPPSGL	(0<<8)
-#define	FPPDBL	(2<<8)
-#define	FPPMASK	(3<<8)
+#define FPINEX (1 << 5)
+#define FPUNFL ((1 << 4) | (1 << 1))
+#define FPOVFL (1 << 3)
+#define FPZDIV (1 << 2)
+#define FPINVAL (1 << 0)
+#define FPRNR (0 << 10)
+#define FPRZ (3 << 10)
+#define FPRPINF (2 << 10)
+#define FPRNINF (1 << 10)
+#define FPRMASK (3 << 10)
+#define FPPEXT (3 << 8)
+#define FPPSGL (0 << 8)
+#define FPPDBL (2 << 8)
+#define FPPMASK (3 << 8)
 /* FSR */
-#define	FPAINEX	FPINEX
-#define	FPAOVFL	FPOVFL
-#define	FPAUNFL	FPUNFL
-#define	FPAZDIV	FPZDIV
-#define	FPAINVAL	FPINVAL
-union FPdbleword
-{
-	double	x;
-	struct {	/* little endian */
-		ulong lo;
-		ulong hi;
-	};
+#define FPAINEX FPINEX
+#define FPAOVFL FPOVFL
+#define FPAUNFL FPUNFL
+#define FPAZDIV FPZDIV
+#define FPAINVAL FPINVAL
+union FPdbleword {
+    double x;
+    struct { /* little endian */
+        ulong lo;
+        ulong hi;
+    };
 };
 
-typedef	char*	va_list;
-#define va_start(list, start) list =\
-	(sizeof(start) < 4?\
-		(char*)((int*)&(start)+1):\
-		(char*)(&(start)+1))
-#define va_end(list)\
-	USED(list)
-#define va_arg(list, mode)\
-	((sizeof(mode) == 1)?\
-		((list += 4), (mode*)list)[-4]:\
-	(sizeof(mode) == 2)?\
-		((list += 4), (mode*)list)[-2]:\
-		((list += sizeof(mode)), (mode*)list)[-1])
+typedef char *va_list;
+#define va_start(list, start)                                                                      \
+    list = (sizeof(start) < 4 ? (char *)((int *)&(start) + 1) : (char *)(&(start) + 1))
+#define va_end(list) USED(list)
+#define va_arg(list, mode)                                                                         \
+    ((sizeof(mode) == 1)   ? ((list += 4), (mode *)list)[-4]                                       \
+     : (sizeof(mode) == 2) ? ((list += 4), (mode *)list)[-2]                                       \
+                           : ((list += sizeof(mode)), (mode *)list)[-1])

--- a/386/include/ureg.h
+++ b/386/include/ureg.h
@@ -1,25 +1,24 @@
-struct Ureg
-{
-	ulong	di;		/* general registers */
-	ulong	si;		/* ... */
-	ulong	bp;		/* ... */
-	ulong	nsp;
-	ulong	bx;		/* ... */
-	ulong	dx;		/* ... */
-	ulong	cx;		/* ... */
-	ulong	ax;		/* ... */
-	ulong	gs;		/* data segments */
-	ulong	fs;		/* ... */
-	ulong	es;		/* ... */
-	ulong	ds;		/* ... */
-	ulong	trap;		/* trap type */
-	ulong	ecode;		/* error code (or zero) */
-	ulong	pc;		/* pc */
-	ulong	cs;		/* old context */
-	ulong	flags;		/* old flags */
-	union {
-		ulong	usp;
-		ulong	sp;
-	};
-	ulong	ss;		/* old stack segment */
+struct Ureg {
+    ulong di; /* general registers */
+    ulong si; /* ... */
+    ulong bp; /* ... */
+    ulong nsp;
+    ulong bx;    /* ... */
+    ulong dx;    /* ... */
+    ulong cx;    /* ... */
+    ulong ax;    /* ... */
+    ulong gs;    /* data segments */
+    ulong fs;    /* ... */
+    ulong es;    /* ... */
+    ulong ds;    /* ... */
+    ulong trap;  /* trap type */
+    ulong ecode; /* error code (or zero) */
+    ulong pc;    /* pc */
+    ulong cs;    /* old context */
+    ulong flags; /* old flags */
+    union {
+        ulong usp;
+        ulong sp;
+    };
+    ulong ss; /* old stack segment */
 };

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+CFLAGS ?=
+CFLAGS += -std=c23 -Wall -Wextra -Wpedantic -Werror
+
+all:
+	$(MAKE) -C modern CFLAGS="$(CFLAGS)" all
+
+clean:
+	$(MAKE) -C modern clean

--- a/acme/bin/source/acd/acd.h
+++ b/acme/bin/source/acd/acd.h
@@ -1,171 +1,168 @@
-#include <u.h>
-#include <libc.h>
+#include <9p.h>
+#include <auth.h>
 #include <bio.h>
 #include <disk.h>
-#include <auth.h>
 #include <fcall.h>
+#include <libc.h>
 #include <thread.h>
-#include <9p.h>
+#include <u.h>
 
 /* acme */
 typedef struct Event Event;
 typedef struct Window Window;
 
-enum
-{
-	STACK		= 16384,
-	EVENTSIZE	= 256,
-	NEVENT		= 5,
+enum {
+    STACK = 16384,
+    EVENTSIZE = 256,
+    NEVENT = 5,
 };
 
-struct Event
-{
-	int	c1;
-	int	c2;
-	int	q0;
-	int	q1;
-	int	flag;
-	int	nb;
-	int	nr;
-	char	b[EVENTSIZE*UTFmax+1];
-	Rune	r[EVENTSIZE+1];
+struct Event {
+    int c1;
+    int c2;
+    int q0;
+    int q1;
+    int flag;
+    int nb;
+    int nr;
+    char b[EVENTSIZE * UTFmax + 1];
+    Rune r[EVENTSIZE + 1];
 };
 
-struct Window
-{
-	/* file descriptors */
-	int		ctl;
-	int		event;
-	int		addr;
-	int		data;
-	Biobuf	*body;
+struct Window {
+    /* file descriptors */
+    int ctl;
+    int event;
+    int addr;
+    int data;
+    Biobuf *body;
 
-	/* event input */
-	char		buf[512];
-	char		*bufp;
-	int		nbuf;
-	Event	e[NEVENT];
+    /* event input */
+    char buf[512];
+    char *bufp;
+    int nbuf;
+    Event e[NEVENT];
 
-	int		id;
-	int		open;
-	Channel	*cevent;	/* chan(Event*) */
+    int id;
+    int open;
+    Channel *cevent; /* chan(Event*) */
 };
 
-extern	Window*	newwindow(void);
-extern	int		winopenfile(Window*, char*);
-extern	void		winopenbody(Window*, int);
-extern	void		winclosebody(Window*);
-extern	void		wintagwrite(Window*, char*, int);
-extern	void		winname(Window*, char*);
-extern	void		winwriteevent(Window*, Event*);
-extern	void		winread(Window*, uint, uint, char*);
-extern	int		windel(Window*, int);
-extern	void		wingetevent(Window*, Event*);
-extern	void		wineventproc(void*);
-extern	void		winwritebody(Window*, char*, int);
-extern	void		winclean(Window*);
-extern	int		winselect(Window*, char*, int);
-extern	int		winsetaddr(Window*, char*, int);
-extern	char*	winreadbody(Window*, int*);
-extern	void		windormant(Window*);
-extern	void		winsetdump(Window*, char*, char*);
+extern Window *newwindow(void);
+extern int winopenfile(Window *, char *);
+extern void winopenbody(Window *, int);
+extern void winclosebody(Window *);
+extern void wintagwrite(Window *, char *, int);
+extern void winname(Window *, char *);
+extern void winwriteevent(Window *, Event *);
+extern void winread(Window *, uint, uint, char *);
+extern int windel(Window *, int);
+extern void wingetevent(Window *, Event *);
+extern void wineventproc(void *);
+extern void winwritebody(Window *, char *, int);
+extern void winclean(Window *);
+extern int winselect(Window *, char *, int);
+extern int winsetaddr(Window *, char *, int);
+extern char *winreadbody(Window *, int *);
+extern void windormant(Window *);
+extern void winsetdump(Window *, char *, char *);
 
-extern	char*	readfile(char*, char*, int*);
-extern	void		ctlprint(int, char*, ...);
-extern	void*	emalloc(uint);
-extern	char*	estrdup(char*);
-extern	char*	estrstrdup(char*, char*);
-extern	char*	egrow(char*, char*, char*);
-extern	char*	eappend(char*, char*, char*);
-extern	void		error(char*, ...);
-extern	int		tokenizec(char*, char**, int, char*);
+extern char *readfile(char *, char *, int *);
+extern void ctlprint(int, char *, ...);
+extern void *emalloc(uint);
+extern char *estrdup(char *);
+extern char *estrstrdup(char *, char *);
+extern char *egrow(char *, char *, char *);
+extern char *eappend(char *, char *, char *);
+extern void error(char *, ...);
+extern int tokenizec(char *, char **, int, char *);
 
 /* cd stuff */
-typedef struct Msf Msf;	/* minute, second, frame */
+typedef struct Msf Msf; /* minute, second, frame */
 struct Msf {
-	int m;
-	int s;
-	int f;
+    int m;
+    int s;
+    int f;
 };
 
 typedef struct Track Track;
 struct Track {
-	Msf start;
-	Msf end;
-	ulong bstart;
-	ulong bend;
-	char *title;
+    Msf start;
+    Msf end;
+    ulong bstart;
+    ulong bend;
+    char *title;
 };
 
 enum {
-	MTRACK = 64,
+    MTRACK = 64,
 };
 typedef struct Toc Toc;
 struct Toc {
-	int ntrack;
-	int nchange;
-	int changetime;
-	int track0;
-	Track track[MTRACK];
-	char *title;
+    int ntrack;
+    int nchange;
+    int changetime;
+    int track0;
+    Track track[MTRACK];
+    char *title;
 };
 
-extern int msfconv(Fmt*);
+extern int msfconv(Fmt *);
 
-#pragma	varargck	argpos	error	1
-#pragma	varargck	argpos	ctlprint	2
-#pragma	varargck	type		"M"	Msf
+#pragma varargck argpos error 1
+#pragma varargck argpos ctlprint 2
+#pragma varargck type "M" Msf
 
-enum {	/* state */
-	Sunknown,
-	Splaying,
-	Spaused,
-	Scompleted,
-	Serror,
+enum { /* state */
+       Sunknown,
+       Splaying,
+       Spaused,
+       Scompleted,
+       Serror,
 };
 
 typedef struct Cdstatus Cdstatus;
 struct Cdstatus {
-	int state;
-	int track;
-	int index;
-	Msf abs;
-	Msf rel;
+    int state;
+    int track;
+    int index;
+    Msf abs;
+    Msf rel;
 };
 
 typedef struct Drive Drive;
 struct Drive {
-	Window *w;
-	Channel *cstatus;	/* chan(Cdstatus) */
-	Channel *ctocdisp;	/* chan(Toc) */
-	Channel *cdbreq;	/* chan(Toc) */
-	Channel *cdbreply; /* chan(Toc) */
-	Scsi *scsi;
-	Toc toc;
-	Cdstatus status;
+    Window *w;
+    Channel *cstatus;  /* chan(Cdstatus) */
+    Channel *ctocdisp; /* chan(Toc) */
+    Channel *cdbreq;   /* chan(Toc) */
+    Channel *cdbreply; /* chan(Toc) */
+    Scsi *scsi;
+    Toc toc;
+    Cdstatus status;
 };
 
-int gettoc(Scsi*, Toc*);
-void drawtoc(Window*, Drive*, Toc*);
-void redrawtoc(Window*, Toc*);
-void tocproc(void*);	/* Drive* */
-void cddbproc(void*);	/* Drive* */
-void cdstatusproc(void*);	/* Drive* */
+int gettoc(Scsi *, Toc *);
+void drawtoc(Window *, Drive *, Toc *);
+void redrawtoc(Window *, Toc *);
+void tocproc(void *);      /* Drive* */
+void cddbproc(void *);     /* Drive* */
+void cdstatusproc(void *); /* Drive* */
 
 extern int debug;
 
-#define DPRINT if(debug)fprint
-void acmeevent(Drive*, Window*, Event*);
+#define DPRINT                                                                                     \
+    if (debug)                                                                                     \
+    fprint
+void acmeevent(Drive *, Window *, Event *);
 
-int playtrack(Drive*, int, int);
-int pause(Drive*);
-int resume(Drive*);
-int stop(Drive*);
-int eject(Drive*);
-int ingest(Drive*);
+int playtrack(Drive *, int, int);
+int pause(Drive *);
+int resume(Drive *);
+int stop(Drive *);
+int eject(Drive *);
+int ingest(Drive *);
 
-int markplay(Window*, ulong);
-int setplaytime(Window*, char*);
-void advancetrack(Drive*, Window*);
-
-
+int markplay(Window *, ulong);
+int setplaytime(Window *, char *);
+void advancetrack(Drive *, Window *);

--- a/acme/bin/source/acd/acme.c
+++ b/acme/bin/source/acd/acme.c
@@ -1,26 +1,23 @@
 #include "acd.h"
 
-static int
-iscmd(char *s, char *cmd)
-{
-	int len;
+static int iscmd(char *s, char *cmd) {
+    int len;
 
-	len = strlen(cmd);
-	return strncmp(s, cmd, len)==0 && (s[len]=='\0' || s[len]==' ' || s[len]=='\t' || s[len]=='\n');
+    len = strlen(cmd);
+    return strncmp(s, cmd, len) == 0 &&
+           (s[len] == '\0' || s[len] == ' ' || s[len] == '\t' || s[len] == '\n');
 }
 
-static char*
-skip(char *s, char *cmd)
-{
-	s += strlen(cmd);
-	while(*s==' ' || *s=='\t' || *s=='\n')
-		s++;
-	return s;
+static char *skip(char *s, char *cmd) {
+    s += strlen(cmd);
+    while (*s == ' ' || *s == '\t' || *s == '\n')
+        s++;
+    return s;
 }
 
-//#define PLAYSTRING "/^[0-9:]+>"
-//#define PLAYSTRINGSPACE "/^[0-9:]+> ?"
-//#define INITSTRING "0:00> "
+// #define PLAYSTRING "/^[0-9:]+>"
+// #define PLAYSTRINGSPACE "/^[0-9:]+> ?"
+// #define INITSTRING "0:00> "
 
 #define INITSTRING "> "
 #define PLAYSTRING "/^>"
@@ -30,52 +27,48 @@ skip(char *s, char *cmd)
  * find the playing string, leave in addr
  * if q0, q1 are non-nil, set them to the addr of the string.
  */
-int
-findplay(Window *w, char *s, ulong *q0, ulong *q1)
-{
-	char xbuf[25];
-	if(w->data < 0)
-		w->data = winopenfile(w, "data");
+int findplay(Window *w, char *s, ulong *q0, ulong *q1) {
+    char xbuf[25];
+    if (w->data < 0)
+        w->data = winopenfile(w, "data");
 
-	if(!winsetaddr(w, "#0", 1) || !winsetaddr(w, s, 1))
-		return 0;
+    if (!winsetaddr(w, "#0", 1) || !winsetaddr(w, s, 1))
+        return 0;
 
-	seek(w->addr, 0, 0);
-	if(read(w->addr, xbuf, 24) != 24)
-		return 0;
-	
-	xbuf[24] = 0;
-	if(q0)
-		*q0 = atoi(xbuf);
-	if(q1)
-		*q1 = atoi(xbuf+12);
+    seek(w->addr, 0, 0);
+    if (read(w->addr, xbuf, 24) != 24)
+        return 0;
 
-	return 1;
+    xbuf[24] = 0;
+    if (q0)
+        *q0 = atoi(xbuf);
+    if (q1)
+        *q1 = atoi(xbuf + 12);
+
+    return 1;
 }
 
 /*
  * find the playing string and replace the time
  */
-int
-setplaytime(Window *w, char *new)
-{
-	char buf[40];
-	ulong q0, q1;
+int setplaytime(Window *w, char *new) {
+    char buf[40];
+    ulong q0, q1;
 
-return 1;
-	if(!findplay(w, PLAYSTRING, &q0, &q1))
-		return 0;
+    return 1;
+    if (!findplay(w, PLAYSTRING, &q0, &q1))
+        return 0;
 
-	q1--;	/* > */
-	sprint(buf, "#%lud,#%lud", q0, q1);
-	DPRINT(2, "setaddr %s\n", buf);
-	if(!winsetaddr(w, buf, 1))
-		return 0;
-	
-	if(write(w->data, new, strlen(new)) != strlen(new))
-		return 0;
+    q1--; /* > */
+    sprint(buf, "#%lud,#%lud", q0, q1);
+    DPRINT(2, "setaddr %s\n", buf);
+    if (!winsetaddr(w, buf, 1))
+        return 0;
 
-	return 1;
+    if (write(w->data, new, strlen(new)) != strlen(new))
+        return 0;
+
+    return 1;
 }
 
 /*
@@ -83,265 +76,251 @@ return 1;
  * return the string at the beginning of hte next line in buf
  * (presumably a track number).
  */
-static int
-unmarkplay(Window *w, char *buf, int n, ulong *q0, ulong *q1, ulong *qbegin)
-{
-	char xbuf[24];
+static int unmarkplay(Window *w, char *buf, int n, ulong *q0, ulong *q1, ulong *qbegin) {
+    char xbuf[24];
 
-	if(!findplay(w, PLAYSTRINGSPACE, q0, q1))
-		return 0;
+    if (!findplay(w, PLAYSTRINGSPACE, q0, q1))
+        return 0;
 
-	if(write(w->data, "", 0) < 0 || !winsetaddr(w, "+1+#0", 1))
-		return 0;
+    if (write(w->data, "", 0) < 0 || !winsetaddr(w, "+1+#0", 1))
+        return 0;
 
-	if(qbegin) {
-		seek(w->addr, 0, 0);
-		if(read(w->addr, xbuf, 24) != 24)
-			return 0;
-		*qbegin = atoi(xbuf);
-	}
+    if (qbegin) {
+        seek(w->addr, 0, 0);
+        if (read(w->addr, xbuf, 24) != 24)
+            return 0;
+        *qbegin = atoi(xbuf);
+    }
 
-	if(buf) {
-		if((n = read(w->data, buf, n-1)) < 0)
-			return 0;
-	
-		buf[n] = '\0';
-	}
+    if (buf) {
+        if ((n = read(w->data, buf, n - 1)) < 0)
+            return 0;
 
-	return 1;
+        buf[n] = '\0';
+    }
+
+    return 1;
 }
 
-int
-markplay(Window *w, ulong q0)
-{
-	char buf[20];
+int markplay(Window *w, ulong q0) {
+    char buf[20];
 
-	if(w->data < 0)
-		w->data = winopenfile(w, "data");
+    if (w->data < 0)
+        w->data = winopenfile(w, "data");
 
-	sprint(buf, "#%lud", q0);
-	DPRINT(2, "addr %s\n", buf);
-	if(!winsetaddr(w, buf, 1) || !winsetaddr(w, "-0", 1))
-		return 0;
-	if(write(w->data, INITSTRING, strlen(INITSTRING)) != strlen(INITSTRING))
-		return 0;
-	return 1;
+    sprint(buf, "#%lud", q0);
+    DPRINT(2, "addr %s\n", buf);
+    if (!winsetaddr(w, buf, 1) || !winsetaddr(w, "-0", 1))
+        return 0;
+    if (write(w->data, INITSTRING, strlen(INITSTRING)) != strlen(INITSTRING))
+        return 0;
+    return 1;
 }
 
 /* return 1 if handled, 0 otherwise */
-int
-cdcommand(Window *w, Drive *d, char *s)
-{
-	s = skip(s, "");
+int cdcommand(Window *w, Drive *d, char *s) {
+    s = skip(s, "");
 
-	if(iscmd(s, "Del")){
-		if(windel(w, 0))
-			threadexitsall(nil);
-		return 1;
-	}
-	if(iscmd(s, "Stop")){
-		unmarkplay(w, nil, 0, nil, nil, nil);
-		stop(d);
-		return 1;
-	}
-	if(iscmd(s, "Eject")){
-		unmarkplay(w, nil, 0, nil, nil, nil);
-		eject(d);
-		return 1;
-	}
-	if(iscmd(s, "Ingest")){
-		unmarkplay(w, nil, 0, nil, nil, nil);
-		ingest(d);
-		return 1;
-	}
-	if(iscmd(s, "Pause")){
-		pause(d);
-		return 1;
-	}
-	if(iscmd(s, "Resume")){
-		resume(d);
-		return 1;
-	}
-	return 0;
+    if (iscmd(s, "Del")) {
+        if (windel(w, 0))
+            threadexitsall(nil);
+        return 1;
+    }
+    if (iscmd(s, "Stop")) {
+        unmarkplay(w, nil, 0, nil, nil, nil);
+        stop(d);
+        return 1;
+    }
+    if (iscmd(s, "Eject")) {
+        unmarkplay(w, nil, 0, nil, nil, nil);
+        eject(d);
+        return 1;
+    }
+    if (iscmd(s, "Ingest")) {
+        unmarkplay(w, nil, 0, nil, nil, nil);
+        ingest(d);
+        return 1;
+    }
+    if (iscmd(s, "Pause")) {
+        pause(d);
+        return 1;
+    }
+    if (iscmd(s, "Resume")) {
+        resume(d);
+        return 1;
+    }
+    return 0;
 }
 
-void
-drawtoc(Window *w, Drive *d, Toc *t)
-{
-	int i, playing;
+void drawtoc(Window *w, Drive *d, Toc *t) {
+    int i, playing;
 
-	if(w->data < 0)
-		w->data = winopenfile(w, "data");
-	if(!winsetaddr(w, ",", 1))
-		return;
+    if (w->data < 0)
+        w->data = winopenfile(w, "data");
+    if (!winsetaddr(w, ",", 1))
+        return;
 
-	fprint(w->data, "Title\n\n");
-	playing = -1;
-	if(d->status.state == Splaying || d->status.state == Spaused)
-		playing = d->status.track-t->track0;
+    fprint(w->data, "Title\n\n");
+    playing = -1;
+    if (d->status.state == Splaying || d->status.state == Spaused)
+        playing = d->status.track - t->track0;
 
-	for(i=0; i<t->ntrack; i++)
-		fprint(w->data, "%s%d/ Track %d\n", i==playing ? "> " : "", i+1, i+1);
-	fprint(w->data, "");
+    for (i = 0; i < t->ntrack; i++)
+        fprint(w->data, "%s%d/ Track %d\n", i == playing ? "> " : "", i + 1, i + 1);
+    fprint(w->data, "");
 }
 
-void
-redrawtoc(Window *w, Toc *t)
-{
-	int i;
-	char old[50];
+void redrawtoc(Window *w, Toc *t) {
+    int i;
+    char old[50];
 
-	if(w->data < 0)
-		w->data = winopenfile(w, "data");
-	if(t->title) {
-		if(winsetaddr(w, "/Title", 1))
-			write(w->data, t->title, strlen(t->title));
-	}
-	for(i=0; i<t->ntrack; i++) {
-		if(t->track[i].title) {
-			sprint(old, "/Track %d", i+1);
-			if(winsetaddr(w, old, 1))
-				write(w->data, t->track[i].title, strlen(t->track[i].title));
-		}
-	}
+    if (w->data < 0)
+        w->data = winopenfile(w, "data");
+    if (t->title) {
+        if (winsetaddr(w, "/Title", 1))
+            write(w->data, t->title, strlen(t->title));
+    }
+    for (i = 0; i < t->ntrack; i++) {
+        if (t->track[i].title) {
+            sprint(old, "/Track %d", i + 1);
+            if (winsetaddr(w, old, 1))
+                write(w->data, t->track[i].title, strlen(t->track[i].title));
+        }
+    }
 }
 
-void
-advancetrack(Drive *d, Window *w)
-{
-	int n;
-	ulong q0, q1, qnext;
-	char buf[20];
+void advancetrack(Drive *d, Window *w) {
+    int n;
+    ulong q0, q1, qnext;
+    char buf[20];
 
-	q0 = q1 = 0;
-	if(!unmarkplay(w, buf, sizeof(buf), &q0, &q1, &qnext)) {
-		DPRINT(2, "unmark: %r\n");
-		return;
-	}
+    q0 = q1 = 0;
+    if (!unmarkplay(w, buf, sizeof(buf), &q0, &q1, &qnext)) {
+        DPRINT(2, "unmark: %r\n");
+        return;
+    }
 
-	DPRINT(2, "buf: %s\n", buf);
-	if(strncmp(buf, "repeat", 6) == 0) {
-		if(!winsetaddr(w, "#0", 1) || !findplay(w, "/^[0-9]+\\/", &qnext, nil)) {
-			DPRINT(2, "set/find: %r\n");
-			return;
-		}
-		if(w->data < 0)
-			w->data = winopenfile(w, "data");
-		if((n = read(w->data, buf, sizeof(buf)-1)) <= 0) {
-			DPRINT(2, "read %d: %r\n", n);
-			return;
-		}
-		buf[n] = 0;
-		DPRINT(2, "buf: %s\n", buf);
-	}
+    DPRINT(2, "buf: %s\n", buf);
+    if (strncmp(buf, "repeat", 6) == 0) {
+        if (!winsetaddr(w, "#0", 1) || !findplay(w, "/^[0-9]+\\/", &qnext, nil)) {
+            DPRINT(2, "set/find: %r\n");
+            return;
+        }
+        if (w->data < 0)
+            w->data = winopenfile(w, "data");
+        if ((n = read(w->data, buf, sizeof(buf) - 1)) <= 0) {
+            DPRINT(2, "read %d: %r\n", n);
+            return;
+        }
+        buf[n] = 0;
+        DPRINT(2, "buf: %s\n", buf);
+    }
 
-	if((n = atoi(buf)) == 0)
-		return;
+    if ((n = atoi(buf)) == 0)
+        return;
 
-	if(!markplay(w, qnext))
-		DPRINT(2, "err: %r");
+    if (!markplay(w, qnext))
+        DPRINT(2, "err: %r");
 
-	playtrack(d, n-1, n-1);
+    playtrack(d, n - 1, n - 1);
 }
 
-void
-acmeevent(Drive *d, Window *w, Event *e)
-{
-	Event *ea, *e2, *eq;
-	char *s, *t, *buf;
-	int n, na;
-	ulong q0, q1;
+void acmeevent(Drive *d, Window *w, Event *e) {
+    Event *ea, *e2, *eq;
+    char *s, *t, *buf;
+    int n, na;
+    ulong q0, q1;
 
-	switch(e->c1){	/* origin of action */
-	default:
-	Unknown:
-		fprint(2, "unknown message %c%c\n", e->c1, e->c2);
-		break;
+    switch (e->c1) { /* origin of action */
+    default:
+    Unknown:
+        fprint(2, "unknown message %c%c\n", e->c1, e->c2);
+        break;
 
-	case 'E':	/* write to body or tag; can't affect us */
-		break;
+    case 'E': /* write to body or tag; can't affect us */
+        break;
 
-	case 'F':	/* generated by our actions; ignore */
-		break;
+    case 'F': /* generated by our actions; ignore */
+        break;
 
-	case 'K':	/* type away; we don't care */
-		break;
+    case 'K': /* type away; we don't care */
+        break;
 
-	case 'M':	/* mouse event */
-		switch(e->c2){		/* type of action */
-		case 'x':	/* mouse: button 2 in tag */
-		case 'X':	/* mouse: button 2 in body */
-			ea = nil;
-		//	e2 = nil;
-			s = e->b;
-			if(e->flag & 2){	/* null string with non-null expansion */
-				e2 = recvp(w->cevent);
-				if(e->nb==0)
-					s = e2->b;
-			}
-			if(e->flag & 8){	/* chorded argument */
-				ea = recvp(w->cevent);	/* argument */
-				na = ea->nb;
-				recvp(w->cevent);		/* ignore origin */
-			}else
-				na = 0;
-			
-			/* append chorded arguments */
-			if(na){
-				t = emalloc(strlen(s)+1+na+1);
-				sprint(t, "%s %s", s, ea->b);
-				s = t;
-			}
-			/* if it's a known command, do it */
-			/* if it's a long message, it can't be for us anyway */
-			DPRINT(2, "exec: %s\n", s);
-			if(!cdcommand(w, d, s))	/* send it back */
-				winwriteevent(w, e);
-			if(na)
-				free(s);
-			break;
+    case 'M':            /* mouse event */
+        switch (e->c2) { /* type of action */
+        case 'x':        /* mouse: button 2 in tag */
+        case 'X':        /* mouse: button 2 in body */
+            ea = nil;
+            //	e2 = nil;
+            s = e->b;
+            if (e->flag & 2) { /* null string with non-null expansion */
+                e2 = recvp(w->cevent);
+                if (e->nb == 0)
+                    s = e2->b;
+            }
+            if (e->flag & 8) {         /* chorded argument */
+                ea = recvp(w->cevent); /* argument */
+                na = ea->nb;
+                recvp(w->cevent); /* ignore origin */
+            } else
+                na = 0;
 
-		case 'l':	/* mouse: button 3 in tag */
-		case 'L':	/* mouse: button 3 in body */
-		//	buf = nil;
-			eq = e;
-			if(e->flag & 2){
-				e2 = recvp(w->cevent);
-				eq = e2;
-			}
-			s = eq->b;
-			if(eq->q1>eq->q0 && eq->nb==0){
-				buf = emalloc((eq->q1-eq->q0)*UTFmax+1);
-				winread(w, eq->q0, eq->q1, buf);
-				s = buf;
-			}
-			DPRINT(2, "load %s\n", s);
-			if((n = atoi(s)) != 0) {
-				DPRINT(2, "mark %d\n", n);
-				q0 = q1 = 0;
-				unmarkplay(w, nil, 0, &q0, &q1, nil);
+            /* append chorded arguments */
+            if (na) {
+                t = emalloc(strlen(s) + 1 + na + 1);
+                sprint(t, "%s %s", s, ea->b);
+                s = t;
+            }
+            /* if it's a known command, do it */
+            /* if it's a long message, it can't be for us anyway */
+            DPRINT(2, "exec: %s\n", s);
+            if (!cdcommand(w, d, s)) /* send it back */
+                winwriteevent(w, e);
+            if (na)
+                free(s);
+            break;
 
-				/* adjust eq->q* for deletion */
-				if(eq->q0 > q1) {
-					eq->q0 -= (q1-q0);
-					eq->q1 -= (q1-q0);
-				}
-				if(!markplay(w, eq->q0))
-					DPRINT(2, "err: %r\n");
+        case 'l': /* mouse: button 3 in tag */
+        case 'L': /* mouse: button 3 in body */
+                  //	buf = nil;
+            eq = e;
+            if (e->flag & 2) {
+                e2 = recvp(w->cevent);
+                eq = e2;
+            }
+            s = eq->b;
+            if (eq->q1 > eq->q0 && eq->nb == 0) {
+                buf = emalloc((eq->q1 - eq->q0) * UTFmax + 1);
+                winread(w, eq->q0, eq->q1, buf);
+                s = buf;
+            }
+            DPRINT(2, "load %s\n", s);
+            if ((n = atoi(s)) != 0) {
+                DPRINT(2, "mark %d\n", n);
+                q0 = q1 = 0;
+                unmarkplay(w, nil, 0, &q0, &q1, nil);
 
-				playtrack(d, n-1, n-1);
-			} else
-				winwriteevent(w, e);
-			break;
+                /* adjust eq->q* for deletion */
+                if (eq->q0 > q1) {
+                    eq->q0 -= (q1 - q0);
+                    eq->q1 -= (q1 - q0);
+                }
+                if (!markplay(w, eq->q0))
+                    DPRINT(2, "err: %r\n");
 
-		case 'i':	/* mouse: text inserted in tag */
-		case 'I':	/* mouse: text inserted in body */
-		case 'd':	/* mouse: text deleted from tag */
-		case 'D':	/* mouse: text deleted from body */
-			break;
+                playtrack(d, n - 1, n - 1);
+            } else
+                winwriteevent(w, e);
+            break;
 
-		default:
-			goto Unknown;
-		}
-	}
+        case 'i': /* mouse: text inserted in tag */
+        case 'I': /* mouse: text inserted in body */
+        case 'd': /* mouse: text deleted from tag */
+        case 'D': /* mouse: text deleted from body */
+            break;
+
+        default:
+            goto Unknown;
+        }
+    }
 }

--- a/acme/bin/source/acd/cddb.c
+++ b/acme/bin/source/acd/cddb.c
@@ -2,196 +2,186 @@
 #include <ctype.h>
 
 /* see CDDBPROTO */
-static ulong 
-cddb_sum(int n)
-{
-	int ret;
-	ret = 0;
-	while(n > 0) {
-		ret += n%10;
-		n /= 10;
-	}
-	return ret;
+static ulong cddb_sum(int n) {
+    int ret;
+    ret = 0;
+    while (n > 0) {
+        ret += n % 10;
+        n /= 10;
+    }
+    return ret;
 }
 
-static ulong
-diskid(Toc *t)
-{
-	int i, n, tmp;
-	Msf *ms, *me;
+static ulong diskid(Toc *t) {
+    int i, n, tmp;
+    Msf *ms, *me;
 
-	n = 0;
-	for(i=0; i < t->ntrack; i++)
-		n += cddb_sum(t->track[i].start.m*60+t->track[i].start.s);
+    n = 0;
+    for (i = 0; i < t->ntrack; i++)
+        n += cddb_sum(t->track[i].start.m * 60 + t->track[i].start.s);
 
-	ms = &t->track[0].start;
-	me = &t->track[t->ntrack].start;
-	tmp = (me->m*60+me->s) - (ms->m*60+ms->s);
+    ms = &t->track[0].start;
+    me = &t->track[t->ntrack].start;
+    tmp = (me->m * 60 + me->s) - (ms->m * 60 + ms->s);
 
-	/*
-	 * the spec says n%0xFF rather than n&0xFF.  it's unclear which is correct.
-	 * most CDs are in the database under both entries.
-	 */
-	return ((n & 0xFF) << 24 | (tmp << 8) | t->ntrack);
+    /*
+     * the spec says n%0xFF rather than n&0xFF.  it's unclear which is correct.
+     * most CDs are in the database under both entries.
+     */
+    return ((n & 0xFF) << 24 | (tmp << 8) | t->ntrack);
 }
 
-static void
-append(char **d, char *s)
-{
-	char *r;
-	if (*d == nil)
-		*d = estrdup(s);
-	else {
-		r = emalloc(strlen(*d) + strlen(s) + 1);
-		strcpy(r, *d);
-		strcat(r, s);
-		free(*d);
-		*d = r;
-	}
+static void append(char **d, char *s) {
+    char *r;
+    if (*d == nil)
+        *d = estrdup(s);
+    else {
+        r = emalloc(strlen(*d) + strlen(s) + 1);
+        strcpy(r, *d);
+        strcat(r, s);
+        free(*d);
+        *d = r;
+    }
 }
 
-static int
-cddbfilltoc(Toc *t)
-{
-	int fd;
-	int i;
-	char *p, *q;
-	Biobuf bin;
-	Msf *m;
-	char *f[10];
-	int nf;
-	char *id, *categ;
-	char gottrack[MTRACK];
-	int gottitle;
+static int cddbfilltoc(Toc *t) {
+    int fd;
+    int i;
+    char *p, *q;
+    Biobuf bin;
+    Msf *m;
+    char *f[10];
+    int nf;
+    char *id, *categ;
+    char gottrack[MTRACK];
+    int gottitle;
 
-	fd = dial("tcp!freedb.freedb.org!888", 0, 0, 0);
-	if(fd < 0) {
-		fprint(2, "cannot dial: %r\n");
-		return -1;
-	}
-	Binit(&bin, fd, OREAD);
+    fd = dial("tcp!freedb.freedb.org!888", 0, 0, 0);
+    if (fd < 0) {
+        fprint(2, "cannot dial: %r\n");
+        return -1;
+    }
+    Binit(&bin, fd, OREAD);
 
-	if((p=Brdline(&bin, '\n')) == nil || atoi(p)/100 != 2) {
-	died:
-		close(fd);
-		Bterm(&bin);
-		fprint(2, "error talking to server\n");
-		if(p) {
-			p[Blinelen(&bin)-1] = 0;
-			fprint(2, "server says: %s\n", p);
-		}
-		return -1;
-	}
+    if ((p = Brdline(&bin, '\n')) == nil || atoi(p) / 100 != 2) {
+    died:
+        close(fd);
+        Bterm(&bin);
+        fprint(2, "error talking to server\n");
+        if (p) {
+            p[Blinelen(&bin) - 1] = 0;
+            fprint(2, "server says: %s\n", p);
+        }
+        return -1;
+    }
 
-	fprint(fd, "cddb hello gre plan9 9cd 1.0\r\n");
-	if((p = Brdline(&bin, '\n')) == nil || atoi(p)/100 != 2)
-		goto died;
+    fprint(fd, "cddb hello gre plan9 9cd 1.0\r\n");
+    if ((p = Brdline(&bin, '\n')) == nil || atoi(p) / 100 != 2)
+        goto died;
 
-	fprint(fd, "cddb query %8.8lux %d", diskid(t), t->ntrack);
-	DPRINT(2, "cddb query %8.8lux %d", diskid(t), t->ntrack);
-	for(i=0; i<t->ntrack; i++) {
-		m = &t->track[i].start;
-		fprint(fd, " %d", (m->m*60+m->s)*75+m->f);
-		DPRINT(2, " %d", (m->m*60+m->s)*75+m->f);
-	}
-	m = &t->track[t->ntrack-1].end;
-	fprint(fd, " %d\r\n", m->m*60+m->s);
-	DPRINT(2, " %d\r\n", m->m*60+m->s);
+    fprint(fd, "cddb query %8.8lux %d", diskid(t), t->ntrack);
+    DPRINT(2, "cddb query %8.8lux %d", diskid(t), t->ntrack);
+    for (i = 0; i < t->ntrack; i++) {
+        m = &t->track[i].start;
+        fprint(fd, " %d", (m->m * 60 + m->s) * 75 + m->f);
+        DPRINT(2, " %d", (m->m * 60 + m->s) * 75 + m->f);
+    }
+    m = &t->track[t->ntrack - 1].end;
+    fprint(fd, " %d\r\n", m->m * 60 + m->s);
+    DPRINT(2, " %d\r\n", m->m * 60 + m->s);
 
-	if((p = Brdline(&bin, '\n')) == nil || atoi(p)/100 != 2)
-		goto died;
-	p[Blinelen(&bin)-1] = 0;
-	DPRINT(2, "cddb: %s\n", p);
-	nf = tokenize(p, f, nelem(f));
-	if(nf < 1)
-		goto died;
+    if ((p = Brdline(&bin, '\n')) == nil || atoi(p) / 100 != 2)
+        goto died;
+    p[Blinelen(&bin) - 1] = 0;
+    DPRINT(2, "cddb: %s\n", p);
+    nf = tokenize(p, f, nelem(f));
+    if (nf < 1)
+        goto died;
 
-	switch(atoi(f[0])) {
-	case 200:	/* exact match */
-		if(nf < 3)
-			goto died;
-		categ = f[1];
-		id = f[2];
-		break;
-	case 211:	/* close matches */
-		if((p = Brdline(&bin, '\n')) == nil)
-			goto died;
-		if(p[0] == '.')	/* no close matches? */
-			goto died;
-		p[Blinelen(&bin)-1] = '\0';
+    switch (atoi(f[0])) {
+    case 200: /* exact match */
+        if (nf < 3)
+            goto died;
+        categ = f[1];
+        id = f[2];
+        break;
+    case 211: /* close matches */
+        if ((p = Brdline(&bin, '\n')) == nil)
+            goto died;
+        if (p[0] == '.') /* no close matches? */
+            goto died;
+        p[Blinelen(&bin) - 1] = '\0';
 
-		/* accept first match */
-		nf = tokenize(p, f, nelem(f));
-		if(nf < 2)
-			goto died;
-		categ = f[0];
-		id = f[1];
+        /* accept first match */
+        nf = tokenize(p, f, nelem(f));
+        if (nf < 2)
+            goto died;
+        categ = f[0];
+        id = f[1];
 
-		/* snarf rest of buffer */
-		while(p[0] != '.') {
-			if((p = Brdline(&bin, '\n')) == nil)
-				goto died;
-			p[Blinelen(&bin)-1] = '\0';
-			DPRINT(2, "cddb: %s\n", p);
-		}
-		break;
-	case 202: /* no match */
-	default:
-		goto died;
-	}
+        /* snarf rest of buffer */
+        while (p[0] != '.') {
+            if ((p = Brdline(&bin, '\n')) == nil)
+                goto died;
+            p[Blinelen(&bin) - 1] = '\0';
+            DPRINT(2, "cddb: %s\n", p);
+        }
+        break;
+    case 202: /* no match */
+    default:
+        goto died;
+    }
 
-	/* fetch results for this cd */
-	fprint(fd, "cddb read %s %s\r\n", categ, id);
+    /* fetch results for this cd */
+    fprint(fd, "cddb read %s %s\r\n", categ, id);
 
-	memset(gottrack, 0, sizeof(gottrack));
-	gottitle = 0;
-	do {
-		if((p = Brdline(&bin, '\n')) == nil)
-			goto died;
-		q = p+Blinelen(&bin)-1;
-		while(isspace(*q))
-			*q-- = 0;
-DPRINT(2, "cddb %s\n", p);
-		if(strncmp(p, "DTITLE=", 7) == 0) {
-			if (gottitle)
-				append(&t->title, p + 7);
-			else
-				t->title = estrdup(p+7);
-			gottitle = 1;
-		} else if(strncmp(p, "TTITLE", 6) == 0 && isdigit(p[6])) {
-			i = atoi(p+6);
-			if(i < t->ntrack) {
-				p += 6;
-				while(isdigit(*p))
-					p++;
-				if(*p == '=')
-					p++;
+    memset(gottrack, 0, sizeof(gottrack));
+    gottitle = 0;
+    do {
+        if ((p = Brdline(&bin, '\n')) == nil)
+            goto died;
+        q = p + Blinelen(&bin) - 1;
+        while (isspace(*q))
+            *q-- = 0;
+        DPRINT(2, "cddb %s\n", p);
+        if (strncmp(p, "DTITLE=", 7) == 0) {
+            if (gottitle)
+                append(&t->title, p + 7);
+            else
+                t->title = estrdup(p + 7);
+            gottitle = 1;
+        } else if (strncmp(p, "TTITLE", 6) == 0 && isdigit(p[6])) {
+            i = atoi(p + 6);
+            if (i < t->ntrack) {
+                p += 6;
+                while (isdigit(*p))
+                    p++;
+                if (*p == '=')
+                    p++;
 
-				if (gottrack[i])
-					append(&t->track[i].title, p);
-				else
-					t->track[i].title = estrdup(p);
-				gottrack[i] = 1;
-			}
-		} 
-	} while(*p != '.');
+                if (gottrack[i])
+                    append(&t->track[i].title, p);
+                else
+                    t->track[i].title = estrdup(p);
+                gottrack[i] = 1;
+            }
+        }
+    } while (*p != '.');
 
-	fprint(fd, "quit\r\n");
-	close(fd);
-	Bterm(&bin);
+    fprint(fd, "quit\r\n");
+    close(fd);
+    Bterm(&bin);
 
-	return 0;
+    return 0;
 }
 
-void
-cddbproc(void *v)
-{
-	Drive *d;
-	Toc t;
+void cddbproc(void *v) {
+    Drive *d;
+    Toc t;
 
-	threadsetname("cddbproc");
-	d = v;
-	while(recv(d->cdbreq, &t))
-		if(cddbfilltoc(&t) == 0)
-			send(d->cdbreply, &t);
+    threadsetname("cddbproc");
+    d = v;
+    while (recv(d->cdbreq, &t))
+        if (cddbfilltoc(&t) == 0)
+            send(d->cdbreply, &t);
 }

--- a/acme/bin/source/acd/main.c
+++ b/acme/bin/source/acd/main.c
@@ -2,134 +2,125 @@
 
 int debug;
 
-void
-usage(void)
-{
-	fprint(2, "usage: acd dev\n");
-	threadexitsall("usage");
+void usage(void) {
+    fprint(2, "usage: acd dev\n");
+    threadexitsall("usage");
 }
 
-Alt
-mkalt(Channel *c, void *v, int op)
-{
-	Alt a;
+Alt mkalt(Channel *c, void *v, int op) {
+    Alt a;
 
-	memset(&a, 0, sizeof(a));
-	a.c = c;
-	a.v = v;
-	a.op = op;
-	return a;
+    memset(&a, 0, sizeof(a));
+    a.c = c;
+    a.v = v;
+    a.op = op;
+    return a;
 }
 
-void
-freetoc(Toc *t)
-{
-	int i;
+void freetoc(Toc *t) {
+    int i;
 
-	free(t->title);
-	for(i=0; i<t->ntrack; i++)
-		free(t->track[i].title);
+    free(t->title);
+    for (i = 0; i < t->ntrack; i++)
+        free(t->track[i].title);
 }
 
-void
-eventwatcher(Drive *d)
-{
-	enum { STATUS, WEVENT, TOCDISP, DBREQ, DBREPLY, NALT };
-	Alt alts[NALT+1];
-	Toc nt, tdb;
-	Event *e;
-	Window *w;
-	Cdstatus s;
-	char buf[40];
+void eventwatcher(Drive *d) {
+    enum { STATUS, WEVENT, TOCDISP, DBREQ, DBREPLY, NALT };
+    Alt alts[NALT + 1];
+    Toc nt, tdb;
+    Event *e;
+    Window *w;
+    Cdstatus s;
+    char buf[40];
 
-	w = d->w;
+    w = d->w;
 
-	alts[STATUS] = mkalt(d->cstatus, &s, CHANRCV);
-	alts[WEVENT] = mkalt(w->cevent, &e, CHANRCV);
-	alts[TOCDISP] = mkalt(d->ctocdisp, &nt, CHANRCV);
-	alts[DBREQ] = mkalt(d->cdbreq, &tdb, CHANNOP);
-	alts[DBREPLY] = mkalt(d->cdbreply, &nt, CHANRCV);
-	alts[NALT] = mkalt(nil, nil, CHANEND);
-	for(;;) {
-		switch(alt(alts)) {
-		case STATUS:
-			//DPRINT(2, "s...");
-			d->status = s;
-			if(s.state == Scompleted) {
-				s.state = Sunknown;
-				advancetrack(d, w);
-			}
-			//DPRINT(2, "status %d %d %d %M %M\n", s.state, s.track, s.index, s.abs, s.rel);
-			sprint(buf, "%d:%2.2d", s.rel.m, s.rel.s);
-			setplaytime(w, buf);
-			break;
-		case WEVENT:
-			//DPRINT(2, "w...");
-			acmeevent(d, w, e);
-			break;
-		case TOCDISP:
-			//DPRINT(2,"td...");
-			freetoc(&d->toc);
-			d->toc = nt;
-			drawtoc(w, d, &d->toc);
-			tdb = nt;
-			alts[DBREQ].op = CHANSND;
-			break;
-		case DBREQ:	/* sent */
-			//DPRINT(2,"dreq...");
-			alts[DBREQ].op = CHANNOP;
-			break;
-		case DBREPLY:
-			//DPRINT(2,"drep...");
-			freetoc(&d->toc);
-			d->toc = nt;
-			redrawtoc(w, &d->toc);
-			break;
-		}
-	}
+    alts[STATUS] = mkalt(d->cstatus, &s, CHANRCV);
+    alts[WEVENT] = mkalt(w->cevent, &e, CHANRCV);
+    alts[TOCDISP] = mkalt(d->ctocdisp, &nt, CHANRCV);
+    alts[DBREQ] = mkalt(d->cdbreq, &tdb, CHANNOP);
+    alts[DBREPLY] = mkalt(d->cdbreply, &nt, CHANRCV);
+    alts[NALT] = mkalt(nil, nil, CHANEND);
+    for (;;) {
+        switch (alt(alts)) {
+        case STATUS:
+            // DPRINT(2, "s...");
+            d->status = s;
+            if (s.state == Scompleted) {
+                s.state = Sunknown;
+                advancetrack(d, w);
+            }
+            // DPRINT(2, "status %d %d %d %M %M\n", s.state, s.track, s.index, s.abs, s.rel);
+            sprint(buf, "%d:%2.2d", s.rel.m, s.rel.s);
+            setplaytime(w, buf);
+            break;
+        case WEVENT:
+            // DPRINT(2, "w...");
+            acmeevent(d, w, e);
+            break;
+        case TOCDISP:
+            // DPRINT(2,"td...");
+            freetoc(&d->toc);
+            d->toc = nt;
+            drawtoc(w, d, &d->toc);
+            tdb = nt;
+            alts[DBREQ].op = CHANSND;
+            break;
+        case DBREQ: /* sent */
+            // DPRINT(2,"dreq...");
+            alts[DBREQ].op = CHANNOP;
+            break;
+        case DBREPLY:
+            // DPRINT(2,"drep...");
+            freetoc(&d->toc);
+            d->toc = nt;
+            redrawtoc(w, &d->toc);
+            break;
+        }
+    }
 }
 
-void
-threadmain(int argc, char **argv)
-{
-	Scsi *s;
-	Drive *d;
-	char buf[80];
+void threadmain(int argc, char **argv) {
+    Scsi *s;
+    Drive *d;
+    char buf[80];
 
-	ARGBEGIN{
-	case 'v':
-		debug++;
-		scsiverbose++;
-	}ARGEND
+    ARGBEGIN {
+    case 'v':
+        debug++;
+        scsiverbose++;
+    }
+    ARGEND
 
-	if(argc != 1)
-		usage();
+    if (argc != 1)
+        usage();
 
-	fmtinstall('M', msfconv);
+    fmtinstall('M', msfconv);
 
-	if((s = openscsi(argv[0])) == nil)
-		error("opening scsi: %r");
+    if ((s = openscsi(argv[0])) == nil)
+        error("opening scsi: %r");
 
-	d = malloc(sizeof(*d));
-	if(d == nil)
-		error("out of memory");
-	memset(d, 0, sizeof d);
+    d = malloc(sizeof(*d));
+    if (d == nil)
+        error("out of memory");
+    memset(d, 0, sizeof d);
 
-	d->scsi = s;
-	d->w = newwindow();
-	d->ctocdisp = chancreate(sizeof(Toc), 0);
-	d->cdbreq = chancreate(sizeof(Toc), 0);
-	d->cdbreply = chancreate(sizeof(Toc), 0);
-	d->cstatus = chancreate(sizeof(Cdstatus), 0);
+    d->scsi = s;
+    d->w = newwindow();
+    d->ctocdisp = chancreate(sizeof(Toc), 0);
+    d->cdbreq = chancreate(sizeof(Toc), 0);
+    d->cdbreply = chancreate(sizeof(Toc), 0);
+    d->cstatus = chancreate(sizeof(Cdstatus), 0);
 
-	proccreate(wineventproc, d->w, STACK);
-	proccreate(cddbproc, d, STACK);
-	proccreate(cdstatusproc, d, STACK);
+    proccreate(wineventproc, d->w, STACK);
+    proccreate(cddbproc, d, STACK);
+    proccreate(cdstatusproc, d, STACK);
 
-	cleanname(argv[0]);
-	snprint(buf, sizeof(buf), "%s/", argv[0]);
-	winname(d->w, buf);
+    cleanname(argv[0]);
+    snprint(buf, sizeof(buf), "%s/", argv[0]);
+    winname(d->w, buf);
 
-	wintagwrite(d->w, "Stop Pause Resume Eject Ingest ", 5+6+7+6+7);
-	eventwatcher(d);
+    wintagwrite(d->w, "Stop Pause Resume Eject Ingest ", 5 + 6 + 7 + 6 + 7);
+    eventwatcher(d);
 }

--- a/acme/bin/source/acd/mmc.c
+++ b/acme/bin/source/acd/mmc.c
@@ -1,303 +1,272 @@
 #include "acd.h"
 
-int
-msfconv(Fmt *fp)
-{
-	Msf m;
+int msfconv(Fmt *fp) {
+    Msf m;
 
-	m = va_arg(fp->args, Msf);
-	fmtprint(fp, "%d.%d.%d", m.m, m.s, m.f);
-	return 0;
+    m = va_arg(fp->args, Msf);
+    fmtprint(fp, "%d.%d.%d", m.m, m.s, m.f);
+    return 0;
 }
 
-static int
-status(Drive *d)
-{
-	uchar cmd[12];
+static int status(Drive *d) {
+    uchar cmd[12];
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0xBD;
-	return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0xBD;
+    return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
 }
 
-static int
-playmsf(Drive *d, Msf start, Msf end)
-{
-	uchar cmd[12];
+static int playmsf(Drive *d, Msf start, Msf end) {
+    uchar cmd[12];
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x47;
-	cmd[3] = start.m;
-	cmd[4] = start.s;
-	cmd[5] = start.f;
-	cmd[6] = end.m;
-	cmd[7] = end.s;
-	cmd[8] = end.f;
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x47;
+    cmd[3] = start.m;
+    cmd[4] = start.s;
+    cmd[5] = start.f;
+    cmd[6] = end.m;
+    cmd[7] = end.s;
+    cmd[8] = end.f;
 
-	return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
+    return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
 }
 
-int
-playtrack(Drive *d, int start, int end)
-{
-	Toc *t;
+int playtrack(Drive *d, int start, int end) {
+    Toc *t;
 
-	t = &d->toc;
+    t = &d->toc;
 
-	if(t->ntrack == 0)
-		return -1;
+    if (t->ntrack == 0)
+        return -1;
 
-	if(start < 0)
-		start = 0;
-	if(end >= t->ntrack)
-		end = t->ntrack-1;
-	if(end < start)
-		end = start;
+    if (start < 0)
+        start = 0;
+    if (end >= t->ntrack)
+        end = t->ntrack - 1;
+    if (end < start)
+        end = start;
 
-	return playmsf(d, t->track[start].start, t->track[end].end);
+    return playmsf(d, t->track[start].start, t->track[end].end);
 }
 
-int
-resume(Drive *d)
-{
-	uchar cmd[12];
+int resume(Drive *d) {
+    uchar cmd[12];
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x4B;
-	cmd[8] = 0x01;
-	return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x4B;
+    cmd[8] = 0x01;
+    return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
 }
 
-int
-pause(Drive *d)
-{
-	uchar cmd[12];
+int pause(Drive *d) {
+    uchar cmd[12];
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x4B;
-	return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x4B;
+    return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
 }
 
-int
-stop(Drive *d)
-{
-	uchar cmd[12];
+int stop(Drive *d) {
+    uchar cmd[12];
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x4E;
-	return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x4E;
+    return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
 }
 
-int
-eject(Drive *d)
-{
-	uchar cmd[12];
+int eject(Drive *d) {
+    uchar cmd[12];
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x1B;
-	cmd[1] = 1;
-	cmd[4] = 2;
-	return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x1B;
+    cmd[1] = 1;
+    cmd[4] = 2;
+    return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
 }
 
-int
-ingest(Drive *d)
-{
-	uchar cmd[12];
+int ingest(Drive *d) {
+    uchar cmd[12];
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x1B;
-	cmd[1] = 1;
-	cmd[4] = 3;
-	return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x1B;
+    cmd[1] = 1;
+    cmd[4] = 3;
+    return scsi(d->scsi, cmd, sizeof cmd, nil, 0, Snone);
 }
 
-static Msf
-rdmsf(uchar *p)
-{
-	Msf msf;
+static Msf rdmsf(uchar *p) {
+    Msf msf;
 
-	msf.m = p[0];
-	msf.s = p[1];
-	msf.f = p[2];
-	return msf;
+    msf.m = p[0];
+    msf.s = p[1];
+    msf.f = p[2];
+    return msf;
 }
 
-static ulong
-rdlba(uchar *p)
-{
-	return (p[0]<<16) | (p[1]<<8) | p[2];
+static ulong rdlba(uchar *p) {
+    return (p[0] << 16) | (p[1] << 8) | p[2];
 }
 
 /* not a Drive, so that we don't accidentally touch Drive.toc */
-int
-gettoc(Scsi *s, Toc *t)
-{
-	int i, n;
-	uchar cmd[12];
-	uchar resp[1024];
+int gettoc(Scsi *s, Toc *t) {
+    int i, n;
+    uchar cmd[12];
+    uchar resp[1024];
 
 Again:
-	memset(t, 0, sizeof(*t));
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x43;
-	cmd[1] = 0x02;
-	cmd[7] = sizeof(resp)>>8;
-	cmd[8] = sizeof(resp);
+    memset(t, 0, sizeof(*t));
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x43;
+    cmd[1] = 0x02;
+    cmd[7] = sizeof(resp) >> 8;
+    cmd[8] = sizeof(resp);
 
-	s->changetime = 1;
-	/* scsi sets nchange, changetime */
-	if(scsi(s, cmd, sizeof cmd, resp, sizeof(resp), Sread) < 4)
-		return -1;
+    s->changetime = 1;
+    /* scsi sets nchange, changetime */
+    if (scsi(s, cmd, sizeof cmd, resp, sizeof(resp), Sread) < 4)
+        return -1;
 
-	if(s->changetime == 0) {
-		t->ntrack = 0;
-		werrstr("no media");
-		return -1;
-	}
+    if (s->changetime == 0) {
+        t->ntrack = 0;
+        werrstr("no media");
+        return -1;
+    }
 
-	if(t->nchange == s->nchange && t->changetime != 0)
-		return 0;
+    if (t->nchange == s->nchange && t->changetime != 0)
+        return 0;
 
-	t->nchange = s->nchange;
-	t->changetime = s->changetime;
+    t->nchange = s->nchange;
+    t->changetime = s->changetime;
 
-	if(t->ntrack > MTRACK)
-		t->ntrack = MTRACK;
+    if (t->ntrack > MTRACK)
+        t->ntrack = MTRACK;
 
-DPRINT(2, "%d %d\n", resp[3], resp[2]);
-	t->ntrack = resp[3]-resp[2]+1;
-	t->track0 = resp[2];
+    DPRINT(2, "%d %d\n", resp[3], resp[2]);
+    t->ntrack = resp[3] - resp[2] + 1;
+    t->track0 = resp[2];
 
-	n = ((resp[0]<<8) | resp[1])+2;
-	if(n < 4+8*(t->ntrack+1)) {
-		werrstr("bad read0 %d %d", n, 4+8*(t->ntrack+1));
-		return -1;
-	}
+    n = ((resp[0] << 8) | resp[1]) + 2;
+    if (n < 4 + 8 * (t->ntrack + 1)) {
+        werrstr("bad read0 %d %d", n, 4 + 8 * (t->ntrack + 1));
+        return -1;
+    }
 
-	for(i=0; i<=t->ntrack; i++)		/* <=: track[ntrack] = end */
-		t->track[i].start = rdmsf(resp+4+i*8+5);
+    for (i = 0; i <= t->ntrack; i++) /* <=: track[ntrack] = end */
+        t->track[i].start = rdmsf(resp + 4 + i * 8 + 5);
 
-	for(i=0; i<t->ntrack; i++)
-		t->track[i].end = t->track[i+1].start;
+    for (i = 0; i < t->ntrack; i++)
+        t->track[i].end = t->track[i + 1].start;
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x43;
-	cmd[7] = sizeof(resp)>>8;
-	cmd[8] = sizeof(resp);
-	if(scsi(s, cmd, sizeof cmd, resp, sizeof(resp), Sread) < 4)
-		return -1;
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x43;
+    cmd[7] = sizeof(resp) >> 8;
+    cmd[8] = sizeof(resp);
+    if (scsi(s, cmd, sizeof cmd, resp, sizeof(resp), Sread) < 4)
+        return -1;
 
-	if(s->changetime != t->changetime || s->nchange != t->nchange) {
-		fprint(2, "disk changed underfoot; repeating\n");
-		goto Again;
-	}
+    if (s->changetime != t->changetime || s->nchange != t->nchange) {
+        fprint(2, "disk changed underfoot; repeating\n");
+        goto Again;
+    }
 
-	n = ((resp[0]<<8) | resp[1])+2;
-	if(n < 4+8*(t->ntrack+1)) {
-		werrstr("bad read");
-		return -1;
-	}
+    n = ((resp[0] << 8) | resp[1]) + 2;
+    if (n < 4 + 8 * (t->ntrack + 1)) {
+        werrstr("bad read");
+        return -1;
+    }
 
-	for(i=0; i<=t->ntrack; i++)
-		t->track[i].bstart = rdlba(resp+4+i*8+5);
+    for (i = 0; i <= t->ntrack; i++)
+        t->track[i].bstart = rdlba(resp + 4 + i * 8 + 5);
 
-	for(i=0; i<t->ntrack; i++)
-		t->track[i].bend = t->track[i+1].bstart;
+    for (i = 0; i < t->ntrack; i++)
+        t->track[i].bend = t->track[i + 1].bstart;
 
-	return 0;
+    return 0;
 }
 
-static void
-dumptoc(Toc *t)
-{
-	int i;
+static void dumptoc(Toc *t) {
+    int i;
 
-	fprint(1, "%d tracks\n", t->ntrack);
-	for(i=0; i<t->ntrack; i++)
-		print("%d. %M-%M (%lud-%lud)\n", i+1,
-			t->track[i].start, t->track[i].end,
-			t->track[i].bstart, t->track[i].bend);
+    fprint(1, "%d tracks\n", t->ntrack);
+    for (i = 0; i < t->ntrack; i++)
+        print("%d. %M-%M (%lud-%lud)\n", i + 1, t->track[i].start, t->track[i].end,
+              t->track[i].bstart, t->track[i].bend);
 }
 
-static void
-ping(Drive *d)
-{
-	uchar cmd[12];
+static void ping(Drive *d) {
+    uchar cmd[12];
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x43;
-	scsi(d->scsi, cmd, sizeof(cmd), nil, 0, Snone);
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x43;
+    scsi(d->scsi, cmd, sizeof(cmd), nil, 0, Snone);
 }
 
-static int
-playstatus(Drive *d, Cdstatus *stat)
-{
-	uchar cmd[12], resp[16];
+static int playstatus(Drive *d, Cdstatus *stat) {
+    uchar cmd[12], resp[16];
 
-	memset(cmd, 0, sizeof cmd);
-	cmd[0] = 0x42;
-	cmd[1] = 0x02;
-	cmd[2] = 0x40;
-	cmd[3] = 0x01;
-	cmd[7] = sizeof(resp)>>8;
-	cmd[8] = sizeof(resp);
-	if(scsi(d->scsi, cmd, sizeof(cmd), resp, sizeof(resp), Sread) < 0)
-		return -1;
+    memset(cmd, 0, sizeof cmd);
+    cmd[0] = 0x42;
+    cmd[1] = 0x02;
+    cmd[2] = 0x40;
+    cmd[3] = 0x01;
+    cmd[7] = sizeof(resp) >> 8;
+    cmd[8] = sizeof(resp);
+    if (scsi(d->scsi, cmd, sizeof(cmd), resp, sizeof(resp), Sread) < 0)
+        return -1;
 
-	switch(resp[1]){
-	case 0x11:
-		stat->state = Splaying;
-		break;
-	case 0x12:
-		stat->state = Spaused;
-		break;
-	case 0x13:
-		stat->state = Scompleted;
-		break;
-	case 0x14:
-		stat->state = Serror;
-		break;
-	case 0x00:	/* not supported */
-	case 0x15:	/* no current status to return */
-	default:
-		stat->state = Sunknown;
-		break;
-	}
+    switch (resp[1]) {
+    case 0x11:
+        stat->state = Splaying;
+        break;
+    case 0x12:
+        stat->state = Spaused;
+        break;
+    case 0x13:
+        stat->state = Scompleted;
+        break;
+    case 0x14:
+        stat->state = Serror;
+        break;
+    case 0x00: /* not supported */
+    case 0x15: /* no current status to return */
+    default:
+        stat->state = Sunknown;
+        break;
+    }
 
-	stat->track = resp[6];
-	stat->index = resp[7];
-	stat->abs = rdmsf(resp+9);
-	stat->rel = rdmsf(resp+13);
-	return 0;
+    stat->track = resp[6];
+    stat->index = resp[7];
+    stat->abs = rdmsf(resp + 9);
+    stat->rel = rdmsf(resp + 13);
+    return 0;
 }
 
-void
-cdstatusproc(void *v)
-{
-	Drive *d;
-	Toc t;
-	Cdstatus s;
+void cdstatusproc(void *v) {
+    Drive *d;
+    Toc t;
+    Cdstatus s;
 
-	t.changetime = ~0;
-	t.nchange = ~0;
+    t.changetime = ~0;
+    t.nchange = ~0;
 
-	threadsetname("cdstatusproc");
-	d = v;
-	DPRINT(2, "cdstatus %d\n", getpid());
-	for(;;) {
-		ping(d);
-	//DPRINT(2, "d %d %d t %d %d\n", d->scsi->changetime, d->scsi->nchange, t.changetime, t.nchange);
-		if(playstatus(d, &s) == 0)
-			send(d->cstatus, &s);
-		if(d->scsi->changetime != t.changetime || d->scsi->nchange != t.nchange) {
-			if(gettoc(d->scsi, &t) == 0) {
-				DPRINT(2, "sendtoc...\n");
-				if(debug) dumptoc(&t);
-				send(d->ctocdisp, &t);
-			} else
-				DPRINT(2, "error: %r\n");
-		}
-		sleep(1000);
-	}
+    threadsetname("cdstatusproc");
+    d = v;
+    DPRINT(2, "cdstatus %d\n", getpid());
+    for (;;) {
+        ping(d);
+        // DPRINT(2, "d %d %d t %d %d\n", d->scsi->changetime, d->scsi->nchange, t.changetime,
+        // t.nchange);
+        if (playstatus(d, &s) == 0)
+            send(d->cstatus, &s);
+        if (d->scsi->changetime != t.changetime || d->scsi->nchange != t.nchange) {
+            if (gettoc(d->scsi, &t) == 0) {
+                DPRINT(2, "sendtoc...\n");
+                if (debug)
+                    dumptoc(&t);
+                send(d->ctocdisp, &t);
+            } else
+                DPRINT(2, "error: %r\n");
+        }
+        sleep(1000);
+    }
 }

--- a/acme/bin/source/acd/toc.c
+++ b/acme/bin/source/acd/toc.c
@@ -2,58 +2,49 @@
 
 Toc thetoc;
 
-void
-tocthread(void *v)
-{
-	Drive *d;
+void tocthread(void *v) {
+    Drive *d;
 
-	threadsetname("tocthread");
-	d = v;
-	DPRINT(2, "recv ctocdisp?...");
-	while(recv(d->ctocdisp, &thetoc) == 1) {
-		DPRINT(2, "recv ctocdisp!...");
-		drawtoc(d->w, &thetoc);
-		DPRINT(2, "send dbreq...\n");
-		send(d->ctocdbreq, &thetoc);
-	}
+    threadsetname("tocthread");
+    d = v;
+    DPRINT(2, "recv ctocdisp?...");
+    while (recv(d->ctocdisp, &thetoc) == 1) {
+        DPRINT(2, "recv ctocdisp!...");
+        drawtoc(d->w, &thetoc);
+        DPRINT(2, "send dbreq...\n");
+        send(d->ctocdbreq, &thetoc);
+    }
 }
 
-void
-freetoc(Toc *t)
-{
-	int i;
+void freetoc(Toc *t) {
+    int i;
 
-	free(t->title);
-	for(i=0; i<t->ntrack; i++)
-		free(t->track[i].title);
+    free(t->title);
+    for (i = 0; i < t->ntrack; i++)
+        free(t->track[i].title);
 }
 
-void
-cddbthread(void *v)
-{
-	Drive *d;
-	Toc t;
+void cddbthread(void *v) {
+    Drive *d;
+    Toc t;
 
-	threadsetname("cddbthread");
-	d = v;
-	while(recv(d->ctocdbreply, &t) == 1) {
-		if(thetoc.nchange == t.nchange) {
-			freetoc(&thetoc);
-			thetoc = t;
-			redrawtoc(d->w, &thetoc);
-		}
-	}
+    threadsetname("cddbthread");
+    d = v;
+    while (recv(d->ctocdbreply, &t) == 1) {
+        if (thetoc.nchange == t.nchange) {
+            freetoc(&thetoc);
+            thetoc = t;
+            redrawtoc(d->w, &thetoc);
+        }
+    }
 }
 
-void
-cdstatusthread(void *v)
-{
-	Drive *d;
-	Cdstatus s;
+void cdstatusthread(void *v) {
+    Drive *d;
+    Cdstatus s;
 
-	d = v;
-	
-	for(;;)
-		recv(d->cstat, &s);
+    d = v;
 
+    for (;;)
+        recv(d->cstat, &s);
 }

--- a/acme/bin/source/acd/util.c
+++ b/acme/bin/source/acd/util.c
@@ -1,89 +1,75 @@
 #include "acd.h"
 
-void*
-emalloc(uint n)
-{
-	void *p;
+void *emalloc(uint n) {
+    void *p;
 
-	p = malloc(n);
-	if(p == nil)
-		error("can't malloc: %r");
-	memset(p, 0, n);
-	return p;
+    p = malloc(n);
+    if (p == nil)
+        error("can't malloc: %r");
+    memset(p, 0, n);
+    return p;
 }
 
-char*
-estrdup(char *s)
-{
-	char *t;
+char *estrdup(char *s) {
+    char *t;
 
-	t = emalloc(strlen(s)+1);
-	strcpy(t, s);
-	return t;
+    t = emalloc(strlen(s) + 1);
+    strcpy(t, s);
+    return t;
 }
 
-char*
-estrstrdup(char *s, char *t)
-{
-	char *u;
+char *estrstrdup(char *s, char *t) {
+    char *u;
 
-	u = emalloc(strlen(s)+strlen(t)+1);
-	strcpy(u, s);
-	strcat(u, t);
-	return u;
+    u = emalloc(strlen(s) + strlen(t) + 1);
+    strcpy(u, s);
+    strcat(u, t);
+    return u;
 }
 
-char*
-eappend(char *s, char *sep, char *t)
-{
-	char *u;
+char *eappend(char *s, char *sep, char *t) {
+    char *u;
 
-	if(t == nil)
-		u = estrstrdup(s, sep);
-	else{
-		u = emalloc(strlen(s)+strlen(sep)+strlen(t)+1);
-		strcpy(u, s);
-		strcat(u, sep);
-		strcat(u, t);
-	}
-	free(s);
-	return u;
+    if (t == nil)
+        u = estrstrdup(s, sep);
+    else {
+        u = emalloc(strlen(s) + strlen(sep) + strlen(t) + 1);
+        strcpy(u, s);
+        strcat(u, sep);
+        strcat(u, t);
+    }
+    free(s);
+    return u;
 }
 
-char*
-egrow(char *s, char *sep, char *t)
-{
-	s = eappend(s, sep, t);
-	free(t);
-	return s;
+char *egrow(char *s, char *sep, char *t) {
+    s = eappend(s, sep, t);
+    free(t);
+    return s;
 }
 
-void
-error(char *fmt, ...)
-{
-	int n;
-	va_list arg;
-	char buf[256];
+void error(char *fmt, ...) {
+    int n;
+    va_list arg;
+    char buf[256];
 
-	fprint(2, "Mail: ");
-	va_start(arg, fmt);
-	n = vsnprint(buf, sizeof buf, fmt, arg);
-	va_end(arg);
-	write(2, buf, n);
-	write(2, "\n", 1);
-	threadexitsall(fmt);
+    fprint(2, "Mail: ");
+    va_start(arg, fmt);
+    n = vsnprint(buf, sizeof buf, fmt, arg);
+    va_end(arg);
+    write(2, buf, n);
+    write(2, "\n", 1);
+    threadexitsall(fmt);
 }
 
-void
-ctlprint(int fd, char *fmt, ...)
-{
-	int n;
-	va_list arg;
-	char buf[256];
+void ctlprint(int fd, char *fmt, ...) {
+    int n;
+    va_list arg;
+    char buf[256];
 
-	va_start(arg, fmt);
-	n = vsnprint(buf, sizeof buf, fmt, arg);
-	va_end(arg);
-	if(write(fd, buf, n) != n)
-		error("control file write error: %r");
+    va_start(arg, fmt);
+    n = vsnprint(buf, sizeof buf, fmt, arg);
+    va_end(arg);
+    if (write(fd, buf, n) != n)
+        error("control file write error: %r");
 }

--- a/acme/bin/source/acd/win.c
+++ b/acme/bin/source/acd/win.c
@@ -1,320 +1,280 @@
 #include "acd.h"
 
-Window*
-newwindow(void)
-{
-	char buf[12];
-	Window *w;
+Window *newwindow(void) {
+    char buf[12];
+    Window *w;
 
-	w = emalloc(sizeof(Window));
-	w->ctl = open("/mnt/wsys/new/ctl", ORDWR|OCEXEC);
-	if(w->ctl<0 || read(w->ctl, buf, 12)!=12)
-		error("can't open window ctl file: %r");
-	ctlprint(w->ctl, "noscroll\n");
-	w->id = atoi(buf);
-	w->event = winopenfile(w, "event");
-	w->addr = -1;	/* will be opened when needed */
-	w->body = nil;
-	w->data = -1;
-	w->cevent = chancreate(sizeof(Event*), 0);
-	if(w->cevent == nil)
-		error("cevent is nil: %r");
-	return w;
+    w = emalloc(sizeof(Window));
+    w->ctl = open("/mnt/wsys/new/ctl", ORDWR | OCEXEC);
+    if (w->ctl < 0 || read(w->ctl, buf, 12) != 12)
+        error("can't open window ctl file: %r");
+    ctlprint(w->ctl, "noscroll\n");
+    w->id = atoi(buf);
+    w->event = winopenfile(w, "event");
+    w->addr = -1; /* will be opened when needed */
+    w->body = nil;
+    w->data = -1;
+    w->cevent = chancreate(sizeof(Event *), 0);
+    if (w->cevent == nil)
+        error("cevent is nil: %r");
+    return w;
 }
 
-void
-winsetdump(Window *w, char *dir, char *cmd)
-{
-	if(dir != nil)
-		ctlprint(w->ctl, "dumpdir %s\n", dir);
-	if(cmd != nil)
-		ctlprint(w->ctl, "dump %s\n", cmd);
+void winsetdump(Window *w, char *dir, char *cmd) {
+    if (dir != nil)
+        ctlprint(w->ctl, "dumpdir %s\n", dir);
+    if (cmd != nil)
+        ctlprint(w->ctl, "dump %s\n", cmd);
 }
 
-void
-wineventproc(void *v)
-{
-	Window *w;
-	int i;
+void wineventproc(void *v) {
+    Window *w;
+    int i;
 
-	threadsetname("wineventproc");
-	w = v;
-	for(i=0; ; i++){
-		if(i >= NEVENT)
-			i = 0;
-		wingetevent(w, &w->e[i]);
-		sendp(w->cevent, &w->e[i]);
-	}
+    threadsetname("wineventproc");
+    w = v;
+    for (i = 0;; i++) {
+        if (i >= NEVENT)
+            i = 0;
+        wingetevent(w, &w->e[i]);
+        sendp(w->cevent, &w->e[i]);
+    }
 }
 
-int
-winopenfile(Window *w, char *f)
-{
-	char buf[64];
-	int fd;
+int winopenfile(Window *w, char *f) {
+    char buf[64];
+    int fd;
 
-	sprint(buf, "/mnt/wsys/%d/%s", w->id, f);
-	fd = open(buf, ORDWR|OCEXEC);
-	if(fd < 0)
-		error("can't open window file %s: %r", f);
-	return fd;
+    sprint(buf, "/mnt/wsys/%d/%s", w->id, f);
+    fd = open(buf, ORDWR | OCEXEC);
+    if (fd < 0)
+        error("can't open window file %s: %r", f);
+    return fd;
 }
 
-void
-wintagwrite(Window *w, char *s, int n)
-{
-	int fd;
+void wintagwrite(Window *w, char *s, int n) {
+    int fd;
 
-	fd = winopenfile(w, "tag");
-	if(write(fd, s, n) != n)
-		error("tag write: %r");
-	close(fd);
+    fd = winopenfile(w, "tag");
+    if (write(fd, s, n) != n)
+        error("tag write: %r");
+    close(fd);
 }
 
-void
-winname(Window *w, char *s)
-{
-	ctlprint(w->ctl, "name %s\n", s);
+void winname(Window *w, char *s) {
+    ctlprint(w->ctl, "name %s\n", s);
 }
 
-void
-winopenbody(Window *w, int mode)
-{
-	char buf[256];
+void winopenbody(Window *w, int mode) {
+    char buf[256];
 
-	sprint(buf, "/mnt/wsys/%d/body", w->id);
-	w->body = Bopen(buf, mode|OCEXEC);
-	if(w->body == nil)
-		error("can't open window body file: %r");
+    sprint(buf, "/mnt/wsys/%d/body", w->id);
+    w->body = Bopen(buf, mode | OCEXEC);
+    if (w->body == nil)
+        error("can't open window body file: %r");
 }
 
-void
-winclosebody(Window *w)
-{
-	if(w->body != nil){
-		Bterm(w->body);
-		w->body = nil;
-	}
+void winclosebody(Window *w) {
+    if (w->body != nil) {
+        Bterm(w->body);
+        w->body = nil;
+    }
 }
 
-void
-winwritebody(Window *w, char *s, int n)
-{
-	if(w->body == nil)
-		winopenbody(w, OWRITE);
-	if(Bwrite(w->body, s, n) != n)
-		error("write error to window: %r");
+void winwritebody(Window *w, char *s, int n) {
+    if (w->body == nil)
+        winopenbody(w, OWRITE);
+    if (Bwrite(w->body, s, n) != n)
+        error("write error to window: %r");
 }
 
-int
-wingetec(Window *w)
-{
-	if(w->nbuf == 0){
-		w->nbuf = read(w->event, w->buf, sizeof w->buf);
-		if(w->nbuf <= 0){
-			/* probably because window has exited, and only called by wineventproc, so just shut down */
-			threadexits(nil);
-		}
-		w->bufp = w->buf;
-	}
-	w->nbuf--;
-	return *w->bufp++;
+int wingetec(Window *w) {
+    if (w->nbuf == 0) {
+        w->nbuf = read(w->event, w->buf, sizeof w->buf);
+        if (w->nbuf <= 0) {
+            /* probably because window has exited, and only called by wineventproc, so just shut
+             * down */
+            threadexits(nil);
+        }
+        w->bufp = w->buf;
+    }
+    w->nbuf--;
+    return *w->bufp++;
 }
 
-int
-wingeten(Window *w)
-{
-	int n, c;
+int wingeten(Window *w) {
+    int n, c;
 
-	n = 0;
-	while('0'<=(c=wingetec(w)) && c<='9')
-		n = n*10+(c-'0');
-	if(c != ' ')
-		error("event number syntax");
-	return n;
+    n = 0;
+    while ('0' <= (c = wingetec(w)) && c <= '9')
+        n = n * 10 + (c - '0');
+    if (c != ' ')
+        error("event number syntax");
+    return n;
 }
 
-int
-wingeter(Window *w, char *buf, int *nb)
-{
-	Rune r;
-	int n;
+int wingeter(Window *w, char *buf, int *nb) {
+    Rune r;
+    int n;
 
-	r = wingetec(w);
-	buf[0] = r;
-	n = 1;
-	if(r >= Runeself) {
-		while(!fullrune(buf, n))
-			buf[n++] = wingetec(w);
-		chartorune(&r, buf);
-	} 
-	*nb = n;
-	return r;
+    r = wingetec(w);
+    buf[0] = r;
+    n = 1;
+    if (r >= Runeself) {
+        while (!fullrune(buf, n))
+            buf[n++] = wingetec(w);
+        chartorune(&r, buf);
+    }
+    *nb = n;
+    return r;
 }
 
-void
-wingetevent(Window *w, Event *e)
-{
-	int i, nb;
+void wingetevent(Window *w, Event *e) {
+    int i, nb;
 
-	e->c1 = wingetec(w);
-	e->c2 = wingetec(w);
-	e->q0 = wingeten(w);
-	e->q1 = wingeten(w);
-	e->flag = wingeten(w);
-	e->nr = wingeten(w);
-	if(e->nr > EVENTSIZE)
-		error("event string too long");
-	e->nb = 0;
-	for(i=0; i<e->nr; i++){
-		e->r[i] = wingeter(w, e->b+e->nb, &nb);
-		e->nb += nb;
-	}
-	e->r[e->nr] = 0;
-	e->b[e->nb] = 0;
-	if(wingetec(w) != '\n')
-		error("event syntax error");
+    e->c1 = wingetec(w);
+    e->c2 = wingetec(w);
+    e->q0 = wingeten(w);
+    e->q1 = wingeten(w);
+    e->flag = wingeten(w);
+    e->nr = wingeten(w);
+    if (e->nr > EVENTSIZE)
+        error("event string too long");
+    e->nb = 0;
+    for (i = 0; i < e->nr; i++) {
+        e->r[i] = wingeter(w, e->b + e->nb, &nb);
+        e->nb += nb;
+    }
+    e->r[e->nr] = 0;
+    e->b[e->nb] = 0;
+    if (wingetec(w) != '\n')
+        error("event syntax error");
 }
 
-void
-winwriteevent(Window *w, Event *e)
-{
-	fprint(w->event, "%c%c%d %d\n", e->c1, e->c2, e->q0, e->q1);
+void winwriteevent(Window *w, Event *e) {
+    fprint(w->event, "%c%c%d %d\n", e->c1, e->c2, e->q0, e->q1);
 }
 
-static int
-nrunes(char *s, int nb)
-{
-	int i, n;
-	Rune r;
+static int nrunes(char *s, int nb) {
+    int i, n;
+    Rune r;
 
-	n = 0;
-	for(i=0; i<nb; n++)
-		i += chartorune(&r, s+i);
-	return n;
+    n = 0;
+    for (i = 0; i < nb; n++)
+        i += chartorune(&r, s + i);
+    return n;
 }
 
-void
-winread(Window *w, uint q0, uint q1, char *data)
-{
-	int m, n, nr;
-	char buf[256];
+void winread(Window *w, uint q0, uint q1, char *data) {
+    int m, n, nr;
+    char buf[256];
 
-	if(w->addr < 0)
-		w->addr = winopenfile(w, "addr");
-	if(w->data < 0)
-		w->data = winopenfile(w, "data");
-	m = q0;
-	while(m < q1){
-		n = sprint(buf, "#%d", m);
-		if(write(w->addr, buf, n) != n)
-			error("error writing addr: %r");
-		n = read(w->data, buf, sizeof buf);
-		if(n <= 0)
-			error("reading data: %r");
-		nr = nrunes(buf, n);
-		while(m+nr >q1){
-			do; while(n>0 && (buf[--n]&0xC0)==0x80);
-			--nr;
-		}
-		if(n == 0)
-			break;
-		memmove(data, buf, n);
-		data += n;
-		*data = 0;
-		m += nr;
-	}
+    if (w->addr < 0)
+        w->addr = winopenfile(w, "addr");
+    if (w->data < 0)
+        w->data = winopenfile(w, "data");
+    m = q0;
+    while (m < q1) {
+        n = sprint(buf, "#%d", m);
+        if (write(w->addr, buf, n) != n)
+            error("error writing addr: %r");
+        n = read(w->data, buf, sizeof buf);
+        if (n <= 0)
+            error("reading data: %r");
+        nr = nrunes(buf, n);
+        while (m + nr > q1) {
+            do
+                ;
+            while (n > 0 && (buf[--n] & 0xC0) == 0x80);
+            --nr;
+        }
+        if (n == 0)
+            break;
+        memmove(data, buf, n);
+        data += n;
+        *data = 0;
+        m += nr;
+    }
 }
 
-void
-windormant(Window *w)
-{
-	if(w->addr >= 0){
-		close(w->addr);
-		w->addr = -1;
-	}
-	if(w->body != nil){
-		Bterm(w->body);
-		w->body = nil;
-	}
-	if(w->data >= 0){
-		close(w->data);
-		w->data = -1;
-	}
+void windormant(Window *w) {
+    if (w->addr >= 0) {
+        close(w->addr);
+        w->addr = -1;
+    }
+    if (w->body != nil) {
+        Bterm(w->body);
+        w->body = nil;
+    }
+    if (w->data >= 0) {
+        close(w->data);
+        w->data = -1;
+    }
 }
 
-
-int
-windel(Window *w, int sure)
-{
-	if(sure)
-		write(w->ctl, "delete\n", 7);
-	else if(write(w->ctl, "del\n", 4) != 4)
-		return 0;
-	/* event proc will die due to read error from event file */
-	windormant(w);
-	close(w->ctl);
-	w->ctl = -1;
-	close(w->event);
-	w->event = -1;
-	return 1;
+int windel(Window *w, int sure) {
+    if (sure)
+        write(w->ctl, "delete\n", 7);
+    else if (write(w->ctl, "del\n", 4) != 4)
+        return 0;
+    /* event proc will die due to read error from event file */
+    windormant(w);
+    close(w->ctl);
+    w->ctl = -1;
+    close(w->event);
+    w->event = -1;
+    return 1;
 }
 
-void
-winclean(Window *w)
-{
-	if(w->body)
-		Bflush(w->body);
-	ctlprint(w->ctl, "clean\n");
+void winclean(Window *w) {
+    if (w->body)
+        Bflush(w->body);
+    ctlprint(w->ctl, "clean\n");
 }
 
-int
-winsetaddr(Window *w, char *addr, int errok)
-{
-	if(w->addr < 0)
-		w->addr = winopenfile(w, "addr");
-	if(write(w->addr, addr, strlen(addr)) < 0){
-		if(!errok)
-			error("error writing addr(%s): %r", addr);
-		return 0;
-	}
-	return 1;
+int winsetaddr(Window *w, char *addr, int errok) {
+    if (w->addr < 0)
+        w->addr = winopenfile(w, "addr");
+    if (write(w->addr, addr, strlen(addr)) < 0) {
+        if (!errok)
+            error("error writing addr(%s): %r", addr);
+        return 0;
+    }
+    return 1;
 }
 
-int
-winselect(Window *w, char *addr, int errok)
-{
-	if(winsetaddr(w, addr, errok)){
-		ctlprint(w->ctl, "dot=addr\n");
-		return 1;
-	}
-	return 0;
+int winselect(Window *w, char *addr, int errok) {
+    if (winsetaddr(w, addr, errok)) {
+        ctlprint(w->ctl, "dot=addr\n");
+        return 1;
+    }
+    return 0;
 }
 
-char*
-winreadbody(Window *w, int *np)	/* can't use readfile because acme doesn't report the length */
+char *winreadbody(Window *w,
+                  int *np) /* can't use readfile because acme doesn't report the length */
 {
-	char *s;
-	int m, na, n;
+    char *s;
+    int m, na, n;
 
-	if(w->body != nil)
-		winclosebody(w);
-	winopenbody(w, OREAD);
-	s = nil;
-	na = 0;
-	n = 0;
-	for(;;){
-		if(na < n+512){
-			na += 1024;
-			s = realloc(s, na+1);
-		}
-		m = Bread(w->body, s+n, na-n);
-		if(m <= 0)
-			break;
-		n += m;
-	}
-	s[n] = 0;
-	winclosebody(w);
-	*np = n;
-	return s;
+    if (w->body != nil)
+        winclosebody(w);
+    winopenbody(w, OREAD);
+    s = nil;
+    na = 0;
+    n = 0;
+    for (;;) {
+        if (na < n + 512) {
+            na += 1024;
+            s = realloc(s, na + 1);
+        }
+        m = Bread(w->body, s + n, na - n);
+        if (m <= 0)
+            break;
+        n += m;
+    }
+    s[n] = 0;
+    winclosebody(w);
+    *np = n;
+    return s;
 }

--- a/clang-tidy.config
+++ b/clang-tidy.config
@@ -1,0 +1,9 @@
+Checks: >
+  -*,
+  bugprone-*,
+  modernize-*,
+  readability-*,
+  performance-*,
+  portability-*,
+  clang-analyzer-*
+WarningsAsErrors: '*'

--- a/modern/Makefile
+++ b/modern/Makefile
@@ -1,14 +1,11 @@
-CC_32 = gcc -m32 -std=c2x -Wall -Wextra -pedantic
-CC_64 = gcc -m64 -std=c2x -Wall -Wextra -pedantic
+CC = clang
+CFLAGS += -std=c23 -Wall -Wextra -Wpedantic -Werror
 SRC = acd_c23.c args.c
 
-all: acd32 acd64
+all: acd
 
-acd32: $(SRC)
-	$(CC_32) $(SRC) -o $@
-
-acd64: $(SRC)
-	$(CC_64) $(SRC) -o $@
+acd: $(SRC)
+	$(CC) $(CFLAGS) $(SRC) -o $@
 
 clean:
-	rm -f acd32 acd64
+	rm -f acd

--- a/modern/acd_c23.c
+++ b/modern/acd_c23.c
@@ -1,12 +1,11 @@
-#include <stdio.h>
-#include <stdbool.h>
-#include "msf.h"
 #include "args.h"
+#include "msf.h"
+#include <stdbool.h>
+#include <stdio.h>
 
 int main(int argc, char **argv) {
     CmdArgs args = parse_args(argc, argv);
-    printf("C23 acd skeleton running on device %s. Verbose=%d\n",
-           args.device, args.verbose);
+    printf("C23 acd skeleton running on device %s. Verbose=%d\n", args.device, args.verbose);
 
     /* TODO: implement SCSI access and event loop using pthreads. */
     Msf start = msf_from_frames(0);

--- a/modern/args.c
+++ b/modern/args.c
@@ -9,7 +9,7 @@ static void usage(void) {
 }
 
 CmdArgs parse_args(int argc, char **argv) {
-    CmdArgs args = {0};
+    CmdArgs args = {.verbose = false, .device = NULL};
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "-v") == 0) {
             args.verbose = true;

--- a/modern/args.h
+++ b/modern/args.h
@@ -8,6 +8,8 @@ typedef struct {
     const char *device;
 } CmdArgs;
 
+_Static_assert(sizeof(int) == 4, "int is not 32-bit");
+
 CmdArgs parse_args(int argc, char **argv);
 
 #endif /* HARVEY_ARGS_H */

--- a/modern/msf.h
+++ b/modern/msf.h
@@ -10,6 +10,8 @@ typedef struct {
     int f;
 } Msf;
 
+_Static_assert(sizeof(int) == 4, "int is not 32-bit");
+
 static inline Msf msf_from_frames(uint32_t frames) {
     Msf msf;
     msf.m = frames / (60 * 75);


### PR DESCRIPTION
## Summary
- modernize Makefiles and switch to `-std=c23`
- add basic clang-format configuration
- add clang-tidy rules
- create CI workflow for formatting and static checks
- apply bulk clang-format to C sources
- use designated initializers and add static assertions

## Testing
- `make clean`
- `make all`
