### PR TITLE
Add qemu-nox helper script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -52,8 +52,11 @@ pip3 install --no-cache-dir \
 #— QEMU emulation for foreign binaries
 for pkg in \
   qemu-user-static \
-  qemu-system-x86 qemu-system-arm qemu-system-aarch64 \
-  qemu-system-riscv64 qemu-system-ppc qemu-system-ppc64 qemu-utils; do
+  qemu-system-x86 qemu-system-x86-64 qemu-system-i386 \
+  qemu-system-arm qemu-system-aarch64 \
+  qemu-system-riscv64 qemu-system-mips qemu-system-mipsel \
+  qemu-system-ppc qemu-system-ppc64 qemu-system-s390x \
+  qemu-system-sparc qemu-utils; do
   apt_pin_install "$pkg"
 done
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Harvey Build Instructions
+
+This repository contains a small subset of the Harvey OS utilities.
+The `.codex/setup.sh` script installs toolchains and QEMU packages
+required for cross development. After the dependencies are installed
+run `make` to build the utilities under the `modern` directory.
+
+To boot a custom Harvey kernel without a graphical console you can use
+`qemu-nox` via the helper script in `scripts/run_qemu_nox.sh`:
+
+```bash
+./scripts/run_qemu_nox.sh path/to/harvey-kernel
+```
+
+The script invokes `qemu-system-x86_64` with the `-nographic` flag so
+that the virtual machine is accessible through the terminal. Append any
+additional QEMU arguments after the kernel path if needed.

--- a/scripts/run_qemu_nox.sh
+++ b/scripts/run_qemu_nox.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run a Harvey kernel in QEMU using a text console.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <harvey_kernel> [extra qemu args...]" >&2
+    exit 1
+fi
+
+KERNEL="$1"
+shift
+
+exec qemu-system-x86_64 -m 512M -nographic -kernel "$KERNEL" "$@"


### PR DESCRIPTION
## Summary
- install a wider set of QEMU system packages in `.codex/setup.sh`
- document basic usage and `qemu-nox` workflow in `README.md`
- add `scripts/run_qemu_nox.sh` to boot a kernel with a text console

## Testing
- `make`
