### PR TITLE
Set up clang-tidy and pre-commit hooks

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -41,7 +41,7 @@ fi
 #— core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
-  clang-format uncrustify astyle editorconfig pre-commit \
+  clang-tidy clang-format uncrustify astyle editorconfig pre-commit \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \
@@ -74,6 +74,7 @@ for pkg in \
   python3-numpy python3-scipy python3-pandas \
   python3-matplotlib python3-scikit-learn \
   python3-torch python3-torchvision python3-torchaudio \
+  python3-yaml \
   python3-onnx python3-onnxruntime; do
   apt_pin_install "$pkg"
 done
@@ -181,6 +182,13 @@ fi
 
 #— gmake alias
 command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
+
+# install git pre-commit hooks if pre-commit is available
+if command -v pre-commit >/dev/null 2>&1; then
+  if ! pre-commit install --install-hooks; then
+    echo "pre-commit install failed" >> "$FAIL_LOG"
+  fi
+fi
 
 #— clean up
 apt-get clean

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ sys/lib/dist/pc/multi
 sys/lib/firmware
 sys/go
 *.acid
+
+# build output
+modern/acd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,27 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+  - repo: local
     hooks:
       - id: trailing-whitespace
+        name: trailing-whitespace
+        entry: hooks/trailing_whitespace.py
+        language: python
+        types: [text]
       - id: end-of-file-fixer
+        name: end-of-file-fixer
+        entry: hooks/end_of_file_fixer.py
+        language: python
+        types: [text]
       - id: check-yaml
+        name: check-yaml
+        entry: hooks/check_yaml.py
+        language: python
+        files: \.(yaml|yml)$
       - id: check-added-large-files
+        name: check-added-large-files
+        entry: hooks/check_added_large_files.py
+        language: python
+      - id: clang-tidy
+        name: clang-tidy
+        entry: hooks/clang_tidy.sh
+        language: script
+        files: \.(c|h)$

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ The `.codex/setup.sh` script installs toolchains and QEMU packages
 required for cross development. After the dependencies are installed
 run `make` to build the utilities under the `modern` directory.
 
+Before committing changes, run `pre-commit` to execute formatters and
+`clang-tidy` checks. The `.codex/setup.sh` script installs the required
+tools and configures the git hook via `pre-commit install`.
+
 To boot a custom Harvey kernel without a graphical console you can use
 `qemu-nox` via the helper script in `scripts/run_qemu_nox.sh`:
 

--- a/hooks/check_added_large_files.py
+++ b/hooks/check_added_large_files.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import os, sys
+MAX_SIZE = 5 * 1024 * 1024
+ret = 0
+for path in sys.argv[1:]:
+    if not os.path.isfile(path):
+        continue
+    if os.path.getsize(path) > MAX_SIZE:
+        print(f"{path}: file exceeds {MAX_SIZE} bytes")
+        ret = 1
+sys.exit(ret)

--- a/hooks/check_yaml.py
+++ b/hooks/check_yaml.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import sys, yaml, pathlib
+ret=0
+for path in sys.argv[1:]:
+    p=pathlib.Path(path)
+    if not p.is_file():
+        continue
+    try:
+        with open(p, 'r') as f:
+            yaml.safe_load(f)
+    except Exception as e:
+        print(f"{path}: YAML parse error: {e}")
+        ret=1
+sys.exit(ret)

--- a/hooks/clang_tidy.sh
+++ b/hooks/clang_tidy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CONFIG_FILE="$(git rev-parse --show-toplevel)/clang-tidy.config"
+for f in "$@"; do
+  clang-tidy --config-file="$CONFIG_FILE" "$f" -- -std=c23
+done

--- a/hooks/end_of_file_fixer.py
+++ b/hooks/end_of_file_fixer.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import sys, pathlib
+changed=False
+for path in sys.argv[1:]:
+    p = pathlib.Path(path)
+    if not p.is_file():
+        continue
+    try:
+        text = p.read_text()
+    except Exception:
+        continue
+    if not text.endswith('\n'):
+        p.write_text(text + '\n')
+        print(f"Added newline at end of file: {path}")
+        changed=True
+sys.exit(1 if changed else 0)

--- a/hooks/trailing_whitespace.py
+++ b/hooks/trailing_whitespace.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import sys, pathlib
+changed=False
+for path in sys.argv[1:]:
+    p = pathlib.Path(path)
+    if not p.is_file():
+        continue
+    try:
+        text = p.read_text()
+    except Exception:
+        continue
+    lines = text.splitlines()
+    new_lines = [line.rstrip(' \t') for line in lines]
+    fixed='\n'.join(new_lines)
+    if text.endswith('\n'):
+        fixed+='\n'
+    if fixed != text:
+        p.write_text(fixed)
+        print(f"Fixed trailing whitespace: {path}")
+        changed=True
+sys.exit(1 if changed else 0)


### PR DESCRIPTION
## Summary
- add local pre-commit hooks so no network access is needed
- run pre-commit install from setup.sh
- install clang-tidy and python-yaml
- document using pre-commit
- ignore build output

## Testing
- `make`
- `./hooks/clang_tidy.sh modern/acd_c23.c` *(fails: 1 warning treated as error)*