### PR TITLE
Add recursive spinlock implementation

### DIFF
--- a/modern/Makefile
+++ b/modern/Makefile
@@ -1,6 +1,6 @@
 CC = clang
-CFLAGS += -std=c23 -Wall -Wextra -Wpedantic -Werror
-SRC = acd_c23.c args.c
+CFLAGS += -std=c23 -Wall -Wextra -Wpedantic -Werror -pthread
+SRC = acd_c23.c args.c spinlock.c
 
 all: acd
 

--- a/modern/acd_c23.c
+++ b/modern/acd_c23.c
@@ -1,5 +1,6 @@
 #include "args.h"
 #include "msf.h"
+#include "spinlock.h"
 #include <stdbool.h>
 #include <stdio.h>
 
@@ -7,9 +8,19 @@ int main(int argc, char **argv) {
     CmdArgs args = parse_args(argc, argv);
     printf("C23 acd skeleton running on device %s. Verbose=%d\n", args.device, args.verbose);
 
+    /* Example use of the recursive spinlock. */
+    Spinlock lock;
+    spinlock_init(&lock);
+    spinlock_acquire(&lock);
+    /* Re-acquire recursively. */
+    spinlock_acquire(&lock);
+
     /* TODO: implement SCSI access and event loop using pthreads. */
     Msf start = msf_from_frames(0);
     printf("Start at %02d:%02d.%02d\n", start.m, start.s, start.f);
+
+    spinlock_release(&lock);
+    spinlock_release(&lock);
 
     return 0;
 }

--- a/modern/spinlock.c
+++ b/modern/spinlock.c
@@ -1,0 +1,29 @@
+#include "spinlock.h"
+#include <assert.h>
+
+void spinlock_init(Spinlock *lock) {
+    atomic_flag_clear(&lock->flag);
+    lock->owner = 0;
+    lock->depth = 0;
+}
+
+void spinlock_acquire(Spinlock *lock) {
+    thrd_t self = thrd_current();
+    if (lock->depth && thrd_equal(lock->owner, self)) {
+        lock->depth++;
+        return;
+    }
+    while (atomic_flag_test_and_set_explicit(&lock->flag, memory_order_acquire)) {
+        ;
+    }
+    lock->owner = self;
+    lock->depth = 1;
+}
+
+void spinlock_release(Spinlock *lock) {
+    assert(lock->depth > 0 && thrd_equal(lock->owner, thrd_current()));
+    if (--lock->depth == 0) {
+        lock->owner = 0;
+        atomic_flag_clear_explicit(&lock->flag, memory_order_release);
+    }
+}

--- a/modern/spinlock.h
+++ b/modern/spinlock.h
@@ -1,0 +1,18 @@
+#ifndef HARVEY_SPINLOCK_H
+#define HARVEY_SPINLOCK_H
+
+#include <stdatomic.h>
+#include <threads.h>
+
+/* Recursive spinlock that can be acquired multiple times by the same thread. */
+typedef struct {
+    atomic_flag flag;
+    thrd_t owner;
+    int depth;
+} Spinlock;
+
+void spinlock_init(Spinlock *lock);
+void spinlock_acquire(Spinlock *lock);
+void spinlock_release(Spinlock *lock);
+
+#endif /* HARVEY_SPINLOCK_H */


### PR DESCRIPTION
## Summary
- add recursive spinlock implementation using C23 atomics
- demonstrate usage in `acd_c23.c`
- update Makefile to build new files

## Testing
- `clang-format --dry-run --Werror modern/acd_c23.c modern/spinlock.h modern/spinlock.c`
- `make -C modern`