### PR TITLE
Install python tools with pip

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -59,6 +59,15 @@ if ! command -v pre-commit >/dev/null 2>&1; then
   fi
 fi
 
+# ensure additional python tools are available via pip
+for pkg in pre-commit configuredb pytest pyyaml pylint pyfuzz; do
+  if ! pip3 show "$pkg" >/dev/null 2>&1; then
+    if ! pip3 install --no-cache-dir "$pkg"; then
+      echo "pip3 install $pkg failed" >> "$FAIL_LOG"
+    fi
+  fi
+done
+
 # ensure yacc command exists
 if ! command -v yacc >/dev/null 2>&1; then
   if command -v byacc >/dev/null 2>&1; then

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MASTER]
+ignore=build
+
+[MESSAGES CONTROL]
+disable=C0114,C0115,C0116

--- a/configuredb.conf
+++ b/configuredb.conf
@@ -1,0 +1,2 @@
+[general]
+configured = true

--- a/pyfuzz.yaml
+++ b/pyfuzz.yaml
@@ -1,0 +1,1 @@
+fuzz_targets: []

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -ra

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,11 @@
+import importlib
+import pytest
+
+def test_pyfuzz_importable():
+    try:
+        importlib.import_module('pyfuzz')
+    except ModuleNotFoundError:
+        pytest.skip('pyfuzz not installed')
+
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- ensure pytest/pylint/pyyaml/pyfuzz/configuredb/pip packages are installed in setup
- add basic pylint and pytest configuration
- add placeholder pyfuzz and configuredb configs
- include a minimal pytest stub

## Testing
- `pytest -q`
- ❌ `pre-commit run --files .codex/setup.sh .pylintrc configuredb.conf pyfuzz.yaml pytest.ini` *(fails: pre-commit not installed)*