### PR TITLE
Install emulators in setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -21,6 +21,14 @@ REQUIRED_PACKAGES=(
   python3-pip
 )
 
+# Emulator packages for Harvey
+REQUIRED_PACKAGES+=(
+  qemu
+  qemu-system-x86
+  qemu-utils
+  bochs
+)
+
 if ! apt-get install -y "${REQUIRED_PACKAGES[@]}"; then
   echo "apt-get install failed" >> "$FAIL_LOG"
 fi

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Harvey Build Instructions
 
 This repository contains a small subset of the Harvey OS utilities.
-The `.codex/setup.sh` script installs toolchains and QEMU packages
-required for cross development. After the dependencies are installed
-run `make` to build the utilities under the `modern` directory.
+The `.codex/setup.sh` script automatically installs the toolchains,
+QEMU and the Bochs emulator along with other packages required for
+cross development. After the dependencies are installed run `make`
+to build the utilities under the `modern` directory.
 
 Before committing changes, run `pre-commit` to execute formatters and
 `clang-tidy` checks. The `.codex/setup.sh` script installs the required


### PR DESCRIPTION
## Summary
- install qemu, qemu-system-x86, qemu-utils, and bochs in setup
- document automatic QEMU/Bochs installation in the README

## Testing
- `make`