### PR TITLE
Replace int asserts with int32_t types

### DIFF
--- a/modern/acd_c23.c
+++ b/modern/acd_c23.c
@@ -2,10 +2,11 @@
 #include "msf.h"
 #include "spinlock.h"
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 
 int main(int argc, char **argv) {
-    CmdArgs args = parse_args(argc, argv);
+    CmdArgs args = parse_args((int32_t)argc, argv);
     printf("C23 acd skeleton running on device %s. Verbose=%d\n", args.device,
            (int)args.verbose);
 

--- a/modern/args.c
+++ b/modern/args.c
@@ -8,9 +8,9 @@ static void usage(void) {
     exit(EXIT_FAILURE);
 }
 
-CmdArgs parse_args(int argc, char **argv) {
+CmdArgs parse_args(int32_t argc, char **argv) {
     CmdArgs args = {.verbose = false, .device = NULL};
-    for (int i = 1; i < argc; ++i) {
+    for (int32_t i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "-v") == 0) {
             args.verbose = true;
         } else if (!args.device) {

--- a/modern/args.h
+++ b/modern/args.h
@@ -2,14 +2,16 @@
 #define HARVEY_ARGS_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef struct {
     bool verbose;
     const char *device;
 } CmdArgs;
 
-_Static_assert(sizeof(int) == 4, "int is not 32-bit");
+/* Use explicit 32-bit type rather than assuming sizeof(int) == 4. */
 
-CmdArgs parse_args(int argc, char **argv);
+
+CmdArgs parse_args(int32_t argc, char **argv);
 
 #endif /* HARVEY_ARGS_H */

--- a/modern/msf.h
+++ b/modern/msf.h
@@ -3,14 +3,14 @@
 
 #include <stdint.h>
 
-/* Minute, second, frame structure from original acd code */
+/* Minute, second, frame structure from original acd code.
+ * Fields use explicit 32-bit types for portability. */
 typedef struct {
-    int m;
-    int s;
-    int f;
+    int32_t m;
+    int32_t s;
+    int32_t f;
 } Msf;
 
-_Static_assert(sizeof(int) == 4, "int is not 32-bit");
 
 enum {
     MSF_SECS_PER_MIN = 60,
@@ -19,10 +19,10 @@ enum {
 
 static inline Msf msf_from_frames(uint32_t frames) {
     Msf msf;
-    msf.m = (int)(frames / (MSF_SECS_PER_MIN * MSF_FRAMES_PER_SEC));
+    msf.m = (int32_t)(frames / (MSF_SECS_PER_MIN * MSF_FRAMES_PER_SEC));
     frames %= MSF_SECS_PER_MIN * MSF_FRAMES_PER_SEC;
-    msf.s = (int)(frames / MSF_FRAMES_PER_SEC);
-    msf.f = (int)(frames % MSF_FRAMES_PER_SEC);
+    msf.s = (int32_t)(frames / MSF_FRAMES_PER_SEC);
+    msf.f = (int32_t)(frames % MSF_FRAMES_PER_SEC);
     return msf;
 }
 


### PR DESCRIPTION
## Summary
- remove assumption that `int` is 32-bit
- use `int32_t` in `args` interface and in `Msf` struct
- cast main's `argc` to the new type and update conversions

## Testing
- `make -C modern`