### PR TITLE
Enable cross-compilation targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
+ARCH ?= x86_64
+ARCHS ?= i386 x86_64
 CFLAGS ?=
 CFLAGS += -std=c23 -Wall -Wextra -Wpedantic -Werror
 
 all:
-	$(MAKE) -C modern CFLAGS="$(CFLAGS)" all
+	$(MAKE) -C modern ARCH=$(ARCH) CFLAGS="$(CFLAGS)" all
+
+test:
+	$(MAKE) -C modern ARCHS="$(ARCHS)" CFLAGS="$(CFLAGS)" test
 
 clean:
 	$(MAKE) -C modern clean

--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ To boot a custom Harvey kernel without a graphical console you can use
 The script invokes `qemu-system-x86_64` with the `-nographic` flag so
 that the virtual machine is accessible through the terminal. Append any
 additional QEMU arguments after the kernel path if needed.
+
+## Cross Compilation
+
+The Makefiles can produce binaries for multiple architectures. Select a
+target by passing the `ARCH` variable to `make`:
+
+```bash
+make ARCH=i386     # build 32-bit binaries
+make ARCH=x86_64   # build 64-bit binaries
+make ARCH=i8086    # experimental 16-bit build
+```
+
+Use `make test` to compile all entries defined in the `ARCHS` variable
+(defaults to `i386 x86_64`).

--- a/modern/Makefile
+++ b/modern/Makefile
@@ -1,11 +1,32 @@
 CC = clang
+ARCH ?= x86_64
+ARCHS ?= i386 x86_64
 CFLAGS += -std=c23 -Wall -Wextra -Wpedantic -Werror -pthread
+
+ifeq ($(ARCH),i386)
+ARCH_FLAGS = -m32
+else ifeq ($(ARCH),x86_64)
+ARCH_FLAGS = -m64
+else ifeq ($(ARCH),i8086)
+ARCH_FLAGS = -m16
+else
+ARCH_FLAGS =
+endif
+
+CFLAGS += $(ARCH_FLAGS)
+
 SRC = acd_c23.c args.c spinlock.c
+OUT = acd-$(ARCH)
 
-all: acd
+all: $(OUT)
 
-acd: $(SRC)
+$(OUT): $(SRC)
 	$(CC) $(CFLAGS) $(SRC) -o $@
 
+test:
+	@for a in $(ARCHS); do \
+		$(MAKE) ARCH=$$a clean all ; \
+	done
+
 clean:
-	rm -f acd
+	rm -f acd-*

--- a/modern/README.md
+++ b/modern/README.md
@@ -12,4 +12,6 @@ small modules to ease future development:
 * `args.c`/`args.h` – minimal command line parsing.
 * `acd_c23.c` – main entry point demonstrating the modernized skeleton.
 
-Run `make` in this directory to build both 32‑bit and 64‑bit binaries.
+Run `make` in this directory to build for the host architecture. Pass
+`ARCH=<target>` to select another architecture or run `make test` to
+compile all targets listed in `ARCHS`.


### PR DESCRIPTION
## Summary
- add `ARCH` and `ARCHS` variables to Makefiles
- compile for multiple targets in modern build
- document `ARCH` usage and `make test` in the README

## Testing
- `pre-commit run --files Makefile README.md modern/Makefile modern/README.md` *(fails: command not found)*
- `make test`