### PR TITLE
Add POSIX thread stubs and documentation

### DIFF
--- a/acme/bin/source/acd/acd.h
+++ b/acme/bin/source/acd/acd.h
@@ -1,3 +1,6 @@
+#ifdef USE_POSIX_THREADS
+#include "../../../../modern/plan9_compat.h"
+#else
 #include <9p.h>
 #include <auth.h>
 #include <bio.h>
@@ -6,6 +9,7 @@
 #include <libc.h>
 #include <thread.h>
 #include <u.h>
+#endif
 
 /* acme */
 typedef struct Event Event;

--- a/docs/acd-plan9-audit.md
+++ b/docs/acd-plan9-audit.md
@@ -1,0 +1,35 @@
+# Porting `acd` away from Plan 9 Threads
+
+The original sources under `acme/bin/source/acd` rely heavily on Plan 9
+libraries. The header `acd.h` includes a number of Plan 9 specific
+interfaces:
+
+```
+#include <9p.h>
+#include <auth.h>
+#include <bio.h>
+#include <disk.h>
+#include <fcall.h>
+#include <libc.h>
+#include <thread.h>
+#include <u.h>
+```
+
+The implementation uses the Plan 9 thread API with entry points like
+`threadmain`, and functions such as `threadexitsall`, `threadexits` and
+`threadsetname`.  Communication between goroutines is performed using the
+`Channel` type, along with helpers like `chancreate`, `send`, `recv` and
+`alt`.
+
+To build these sources on a standard POSIX system a small compatibility
+layer can map the Plan 9 APIs to `pthread` primitives.  The header
+`modern/plan9_compat.h` provides minimal stubs for channels and thread
+management when compiled with `-DUSE_POSIX_THREADS`.  It defines
+`threadmain` as `main`, implements `proccreate` using `pthread_create`
+and emulates `Channel` operations with mutexes and condition variables.
+
+This layer is only intended for compilation and further modernization
+work; it does not perfectly reproduce Plan 9 semantics.  A full port
+would replace the channel based concurrency with standard POSIX queues or
+other C23 facilities.
+

--- a/modern/plan9_compat.h
+++ b/modern/plan9_compat.h
@@ -1,0 +1,137 @@
+#ifndef PLAN9_COMPAT_H
+#define PLAN9_COMPAT_H
+
+#ifdef USE_POSIX_THREADS
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct Channel {
+    pthread_mutex_t m;
+    pthread_cond_t c;
+    void *buf;
+    size_t size;
+    int ready;
+} Channel;
+
+typedef struct Alt Alt;
+struct Alt {
+    Channel *c;
+    void *v;
+    int op;
+};
+
+enum { CHANSND, CHANRCV, CHANNOP, CHANEND };
+
+static inline Channel *chancreate(size_t size, int buffered) {
+    Channel *ch = malloc(sizeof(Channel));
+    if (!ch) return NULL;
+    pthread_mutex_init(&ch->m, NULL);
+    pthread_cond_init(&ch->c, NULL);
+    ch->buf = malloc(size);
+    ch->size = size;
+    ch->ready = 0;
+    (void)buffered;
+    return ch;
+}
+
+static inline int send(Channel *ch, void *v) {
+    pthread_mutex_lock(&ch->m);
+    memcpy(ch->buf, v, ch->size);
+    ch->ready = 1;
+    pthread_cond_signal(&ch->c);
+    pthread_mutex_unlock(&ch->m);
+    return 1;
+}
+
+static inline int recv(Channel *ch, void *v) {
+    pthread_mutex_lock(&ch->m);
+    while (!ch->ready)
+        pthread_cond_wait(&ch->c, &ch->m);
+    memcpy(v, ch->buf, ch->size);
+    ch->ready = 0;
+    pthread_mutex_unlock(&ch->m);
+    return 1;
+}
+
+static inline int sendp(Channel *ch, void *v) {
+    pthread_mutex_lock(&ch->m);
+    ch->buf = v;
+    ch->ready = 1;
+    pthread_cond_signal(&ch->c);
+    pthread_mutex_unlock(&ch->m);
+    return 1;
+}
+
+static inline void *recvp(Channel *ch) {
+    pthread_mutex_lock(&ch->m);
+    while (!ch->ready)
+        pthread_cond_wait(&ch->c, &ch->m);
+    void *v = ch->buf;
+    ch->ready = 0;
+    pthread_mutex_unlock(&ch->m);
+    return v;
+}
+
+static inline Alt mkalt(Channel *c, void *v, int op) {
+    Alt a;
+    a.c = c;
+    a.v = v;
+    a.op = op;
+    return a;
+}
+
+static inline int alt(Alt *a) {
+    for (int i = 0;; ++i) {
+        switch (a[i].op) {
+        case CHANRCV:
+            if (recv(a[i].c, a[i].v))
+                return i;
+            break;
+        case CHANSND:
+            if (send(a[i].c, a[i].v)) {
+                a[i].op = CHANNOP;
+                return i;
+            }
+            break;
+        case CHANEND:
+            return -1;
+        default:
+            break;
+        }
+    }
+}
+
+static inline int proccreate(void (*fn)(void *), void *arg, unsigned stack) {
+    pthread_t t;
+    (void)stack;
+    return pthread_create(&t, NULL, (void *(*)(void *))fn, arg) == 0;
+}
+
+static inline void threadsetname(const char *name) {
+#if defined(__linux__)
+    pthread_setname_np(pthread_self(), name);
+#elif defined(__APPLE__)
+    pthread_setname_np(name);
+#else
+    (void)name;
+#endif
+}
+
+static inline void threadexitsall(const char *msg) {
+    (void)msg;
+    exit(0);
+}
+
+static inline void threadexits(const char *msg) {
+    (void)msg;
+    pthread_exit(NULL);
+}
+
+#define threadmain main
+
+#else
+#include <thread.h>
+#endif
+
+#endif /* PLAN9_COMPAT_H */


### PR DESCRIPTION
## Summary
- document Plan 9 dependencies found in `acme/bin/source/acd`
- add a small compatibility header implementing thread/channel stubs using pthreads
- allow `acd.h` to include the compatibility layer when `USE_POSIX_THREADS` is defined

## Testing
- `bash .codex/setup.sh` *(fails: Could not connect to proxy)*