### PR TITLE
Modernize build setup and tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential clang clang-tidy make gcc-multilib g++-multilib python3 python3-pip
-          pip3 install pre-commit
+        run: ./setup.sh
       - name: Build
         run: make CFLAGS="${{ matrix.cflags }}"
       - name: Run pre-commit
         run: pre-commit run --all-files
       - name: clang-tidy
         run: |
-          clang-tidy --config-file=clang-tidy.config $(find . -name '*.c' -o -name '*.h') -- -std=c23 ${{ matrix.cflags }}
+          clang-tidy --config-file=clang-tidy.config $(find . -name '*.c' -o -name '*.h') -- -std=c17 ${{ matrix.cflags }}

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -11,5 +11,7 @@ jobs:
         with:
           style: file
           path: "**/*.{c,h}"
-      - run: make all CFLAGS+=' -std=c23 -Wall -Wextra -Wpedantic -Werror'
-      - run: clang-tidy --config-file=clang-tidy.config $(find . -name '*.c' -o -name '*.h') -- -std=c23
+      - name: Install dependencies
+        run: ./setup.sh
+      - run: make all CFLAGS+=' -std=c17 -Wall -Wextra -Wpedantic -Werror'
+      - run: clang-tidy --config-file=clang-tidy.config $(find . -name '*.c' -o -name '*.h') -- -std=c17

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
+# Root Makefile to drive builds in the modern directory
 ARCH ?= x86_64
 ARCHS ?= i386 x86_64
-CFLAGS ?=
-CFLAGS += -std=c23 -Wall -Wextra -Wpedantic -Werror
+CC ?= clang
+CXX ?= clang++
+CFLAGS ?= -std=c17 -Wall -Wextra -Wpedantic -Werror
+CXXFLAGS ?= -std=c++17 -Wall -Wextra -Wpedantic -Werror
 
+# Build the modern utilities for the selected ARCH
+.PHONY: all test clean
 all:
-	$(MAKE) -C modern ARCH=$(ARCH) CFLAGS="$(CFLAGS)" all
+	$(MAKE) -C modern ARCH=$(ARCH) CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" all
 
 test:
-	$(MAKE) -C modern ARCHS="$(ARCHS)" CFLAGS="$(CFLAGS)" test
+	$(MAKE) -C modern ARCHS="$(ARCHS)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" test
 
 clean:
 	$(MAKE) -C modern clean

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # Harvey Build Instructions
 
 This repository contains a small subset of the Harvey OS utilities.
-The `.codex/setup.sh` script automatically installs the toolchains,
+The `./setup.sh` script automatically installs the toolchains,
 QEMU and the Bochs emulator along with other packages required for
 cross development. After the dependencies are installed run `make`
 to build the utilities under the `modern` directory.
 
+The setup script also installs additional packages for 32-bit
+cross compilation, Go tooling, and various utilities used by the
+CI workflows. These include `gcc-multilib`, `g++-multilib`, `rc`,
+`expect`, `go-dep`, `golang-go` and the `PyYAML` Python module.
+
 Before committing changes, run `pre-commit` to execute formatters and
-`clang-tidy` checks. The `.codex/setup.sh` script installs the required
+`clang-tidy` checks. The `./setup.sh` script installs the required
 tools and configures the git hook via `pre-commit install`.
 
 To boot a custom Harvey kernel without a graphical console you can use

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -1,18 +1,18 @@
 # Modernization Plan
 
-This document outlines the high level tasks required to refactor the Harvey utilities to modern C23, C++23 and portable assembly.
+This document outlines the high level tasks required to refactor the Harvey utilities to modern C17, C++17 and portable assembly.
 
-## C23 Migration
+## C17 Migration
 
 - Audit existing C sources for deprecated constructs and Plan 9 specific extensions.
-- Introduce a portable build system using clang with `-std=c23`.
+- Introduce a portable build system using clang with `-std=c17`.
 - Enable compiler warnings for portability issues and adopt clang-tidy modernize checks.
 
-## C++23 Components
+## C++17 Components
 
 - Identify subsystems that would benefit from C++ abstractions, e.g. file handling or command line parsing.
 - Establish a minimal runtime environment compatible with both C and C++ utilities.
-- Compile C++ sources using `-std=c++23` and integrate with the existing makefiles.
+- Compile C++ sources using `-std=c++17` and integrate with the existing makefiles.
 
 ## Portable Assembly
 

--- a/hooks/clang_tidy.sh
+++ b/hooks/clang_tidy.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 CONFIG_FILE="$(git rev-parse --show-toplevel)/clang-tidy.config"
 for f in "$@"; do
-  clang-tidy --config-file="$CONFIG_FILE" "$f" -- -std=c23
+  clang-tidy --config-file="$CONFIG_FILE" "$f" -- -std=c17
 done

--- a/modern/Makefile
+++ b/modern/Makefile
@@ -1,7 +1,12 @@
-CC = clang
+# Makefile for modern utilities. Builds the acd example.
+CC ?= clang
+CXX ?= clang++
 ARCH ?= x86_64
 ARCHS ?= i386 x86_64
-CFLAGS += -std=c23 -Wall -Wextra -Wpedantic -Werror -pthread
+# Common compiler flags for C sources
+CFLAGS ?= -Wall -Wextra -Wpedantic -Werror -std=c17 -pthread
+# Common compiler flags for C++ sources
+CXXFLAGS ?= -Wall -Wextra -Wpedantic -Werror -std=c++17 -pthread
 
 ifeq ($(ARCH),i386)
 ARCH_FLAGS = -m32
@@ -14,19 +19,22 @@ ARCH_FLAGS =
 endif
 
 CFLAGS += $(ARCH_FLAGS)
+CXXFLAGS += $(ARCH_FLAGS)
 
-SRC = acd_c23.c args.c spinlock.c
+SRC = acd.c args.c spinlock.c
 OUT = acd-$(ARCH)
 
+# Default target builds the binary for the selected ARCH
+.PHONY: all test clean
 all: $(OUT)
 
 $(OUT): $(SRC)
-	$(CC) $(CFLAGS) $(SRC) -o $@
+	        $(CC) $(CFLAGS) $(SRC) -o $@
 
 test:
-	@for a in $(ARCHS); do \
-		$(MAKE) ARCH=$$a clean all ; \
-	done
+	        @for a in $(ARCHS); do \
+	                $(MAKE) ARCH=$$a clean all ; \
+        done
 
 clean:
-	rm -f acd-*
+		rm -f acd-*

--- a/modern/README.md
+++ b/modern/README.md
@@ -1,7 +1,7 @@
-# Modern C23 port
+# Modern C17 port
 
 This directory contains experimental work to rewrite parts of the original
-Harvey OS utilities into standard C23. The goal is to eventually build
+Harvey OS utilities into standard C17. The goal is to eventually build
 portable versions that target both 32‑bit and 64‑bit x86 systems without
 relying on the original Plan 9 libraries.
 
@@ -10,7 +10,7 @@ small modules to ease future development:
 
 * `msf.h` – helper for dealing with CD minute/second/frame values.
 * `args.c`/`args.h` – minimal command line parsing.
-* `acd_c23.c` – main entry point demonstrating the modernized skeleton.
+* `acd.c` – main entry point demonstrating the modernized skeleton.
 
 Run `make` in this directory to build for the host architecture. Pass
 `ARCH=<target>` to select another architecture or run `make test` to

--- a/modern/acd.c
+++ b/modern/acd.c
@@ -1,4 +1,5 @@
-#include "args.h"
+/* Example CD player skeleton using modern threading primitives. */
+#include "args.h" /* command line parser */
 #include "msf.h"
 #include "spinlock.h"
 #include <stdbool.h>
@@ -7,8 +8,7 @@
 
 int main(int argc, char **argv) {
     CmdArgs args = parse_args((int32_t)argc, argv);
-    printf("C23 acd skeleton running on device %s. Verbose=%d\n", args.device,
-           (int)args.verbose);
+    printf("C23 acd skeleton running on device %s. Verbose=%d\n", args.device, (int)args.verbose);
 
     /* Example use of the recursive spinlock. */
     Spinlock lock;

--- a/modern/args.c
+++ b/modern/args.c
@@ -1,3 +1,4 @@
+/* Simple argument parser for the acd utility. */
 #include "args.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/modern/spinlock.c
+++ b/modern/spinlock.c
@@ -1,3 +1,4 @@
+/* Recursive spinlock implementation using C11 atomics. */
 #include "spinlock.h"
 #include <assert.h>
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# A living setup script used by Codex to install dependencies. It attempts to
+# Root environment setup script used to install all dependencies.
+# It attempts to
 # install packages via apt, then falls back to pip and npm if needed. Any
 # failures are logged but the script continues.
 set -euo pipefail
@@ -56,6 +57,7 @@ REQUIRED_PACKAGES=(
   git
   python3
   python3-pip
+  python3-yaml
   shellcheck
   graphviz
   doxygen
@@ -64,6 +66,12 @@ REQUIRED_PACKAGES=(
   coq
   isabelle
   capnproto
+  gcc-multilib
+  g++-multilib
+  rc
+  expect
+  go-dep
+  golang-go
 )
 
 # Emulator packages for Harvey
@@ -81,6 +89,11 @@ done
 # Install pre-commit via pip
 if ! pip3 install --no-cache-dir pre-commit; then
   echo "pip3 install pre-commit failed" >> "$FAIL_LOG"
+fi
+
+# Install PyYAML for Python hooks
+if ! pip3 install --no-cache-dir pyyaml; then
+  echo "pip3 install pyyaml failed" >> "$FAIL_LOG"
 fi
 
 # Install git pre-commit hooks


### PR DESCRIPTION
## Summary
- promote root setup.sh as the single dependency installer
- switch C code to C17 and C++ to C++17
- refresh docs and Makefiles to match the new standards
- update CI workflows and clang-tidy hook
- rename `acd_c23.c` to `acd.c` and add comments

## Testing
- `make`
- `make test`
- `clang-tidy --config-file=clang-tidy.config modern/args.c -- -std=c17`
- `pre-commit` *(fails: command not found)*
- `bash setup.sh` *(fails: apt-get update due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6839f5be2ee88331bd1c0f4849192554