### PR TITLE
Refine logging macro and format headers

### DIFF
--- a/386/include/u.h
+++ b/386/include/u.h
@@ -6,16 +6,16 @@
 
 /* Basic type aliases using modern C17 fixed-width types. */
 #define nil ((void *)0)
-typedef uint16_t ushort;
-typedef uint8_t uchar;
-typedef unsigned long ulong;
-typedef uint32_t uint;
-typedef int8_t schar;
-typedef int64_t vlong;
-typedef uint64_t uvlong;
-typedef uintptr_t uintptr;
-typedef size_t usize;
-typedef uint32_t Rune;
+typedef uint16_t ushort;     /* 16-bit unsigned integer */
+typedef uint8_t uchar;       /* 8-bit unsigned integer */
+typedef unsigned long ulong; /* native unsigned long */
+typedef uint32_t uint;       /* 32-bit unsigned integer */
+typedef int8_t schar;        /* 8-bit signed integer */
+typedef int64_t vlong;       /* 64-bit signed integer */
+typedef uint64_t uvlong;     /* 64-bit unsigned integer */
+typedef uintptr_t uintptr;   /* unsigned integer the size of a pointer */
+typedef size_t usize;        /* alias for size_t */
+typedef uint32_t Rune;       /* Unicode code point */
 
 typedef union FPdbleword FPdbleword;
 typedef long jmp_buf[2];
@@ -23,10 +23,10 @@ typedef long jmp_buf[2];
 #define JMPBUFPC 1
 #define JMPBUFDPC 0
 typedef unsigned int mpdigit; /* for /sys/include/mp.h */
-typedef uint8_t u8int;
-typedef uint16_t u16int;
-typedef uint32_t u32int;
-typedef uint64_t u64int;
+typedef uint8_t u8int;        /* 8-bit unsigned integer */
+typedef uint16_t u16int;      /* 16-bit unsigned integer */
+typedef uint32_t u32int;      /* 32-bit unsigned integer */
+typedef uint64_t u64int;      /* 64-bit unsigned integer */
 
 /* FCR */
 #define FPINEX (1 << 5)

--- a/acme/bin/source/acd/acd.h
+++ b/acme/bin/source/acd/acd.h
@@ -2,7 +2,6 @@
 
 /*
  * C17 header for the acd utility.  The original Plan9 dependencies
- * have been removed and replaced with forward declarations and
  * standard C headers so the code can be compiled as freestanding
  * C17.
  */
@@ -16,9 +15,12 @@ typedef struct Biobuf Biobuf;
 typedef struct Channel Channel;
 typedef struct Scsi Scsi;
 
-/* Simple stand-ins for historical Plan9 types. */
-typedef unsigned long ulong;
-typedef uint32_t uint;
+/* Simple stand-ins for historical Plan9 types.
+ * These aliases mirror the common Plan 9 names while
+ * using explicit C99 fixed-width types for clarity.
+ */
+typedef unsigned long ulong; /* native unsigned long */
+typedef uint32_t uint;       /* 32-bit unsigned integer */
 
 /* acme */
 typedef struct Fmt Fmt; /* Formatting context placeholder */
@@ -161,11 +163,15 @@ void tocproc(void *);      /* Drive* */
 void cddbproc(void *);     /* Drive* */
 void cdstatusproc(void *); /* Drive* */
 
+/* Global debug level controlling verbosity of diagnostic output. */
 extern int debug;
 
-#define DPRINT                                                                                     \
-    if (debug)                                                                                     \
-    fprint
+/* Debug logging helper with a verbosity level. */
+#define LOG(level, ...)                                                                            \
+    do {                                                                                           \
+        if (debug >= (level))                                                                      \
+            fprintf(stderr, __VA_ARGS__);                                                          \
+    } while (0)
 void acmeevent(Drive *, Window *, Event *);
 
 int playtrack(Drive *, int, int);

--- a/acme/bin/source/acd/acme.c
+++ b/acme/bin/source/acd/acme.c
@@ -62,7 +62,7 @@ int setplaytime(Window *w, char *new) {
 
     q1--; /* > */
     sprint(buf, "#%lud,#%lud", q0, q1);
-    DPRINT(2, "setaddr %s\n", buf);
+    LOG(2, "setaddr %s\n", buf);
     if (!winsetaddr(w, buf, 1))
         return 0;
 
@@ -110,7 +110,7 @@ int markplay(Window *w, ulong q0) {
         w->data = winopenfile(w, "data");
 
     sprint(buf, "#%lud", q0);
-    DPRINT(2, "addr %s\n", buf);
+    LOG(2, "addr %s\n", buf);
     if (!winsetaddr(w, buf, 1) || !winsetaddr(w, "-0", 1))
         return 0;
     if (write(w->data, INITSTRING, strlen(INITSTRING)) != strlen(INITSTRING))
@@ -197,31 +197,31 @@ void advancetrack(Drive *d, Window *w) {
 
     q0 = q1 = 0;
     if (!unmarkplay(w, buf, sizeof(buf), &q0, &q1, &qnext)) {
-        DPRINT(2, "unmark: %r\n");
+        LOG(2, "unmark: %r\n");
         return;
     }
 
-    DPRINT(2, "buf: %s\n", buf);
+    LOG(2, "buf: %s\n", buf);
     if (strncmp(buf, "repeat", 6) == 0) {
         if (!winsetaddr(w, "#0", 1) || !findplay(w, "/^[0-9]+\\/", &qnext, NULL)) {
-            DPRINT(2, "set/find: %r\n");
+            LOG(2, "set/find: %r\n");
             return;
         }
         if (w->data < 0)
             w->data = winopenfile(w, "data");
         if ((n = read(w->data, buf, sizeof(buf) - 1)) <= 0) {
-            DPRINT(2, "read %d: %r\n", n);
+            LOG(2, "read %d: %r\n", n);
             return;
         }
         buf[n] = 0;
-        DPRINT(2, "buf: %s\n", buf);
+        LOG(2, "buf: %s\n", buf);
     }
 
     if ((n = atoi(buf)) == 0)
         return;
 
     if (!markplay(w, qnext))
-        DPRINT(2, "err: %r");
+        LOG(2, "err: %r");
 
     playtrack(d, n - 1, n - 1);
 }
@@ -274,7 +274,7 @@ void acmeevent(Drive *d, Window *w, Event *e) {
             }
             /* if it's a known command, do it */
             /* if it's a long message, it can't be for us anyway */
-            DPRINT(2, "exec: %s\n", s);
+            LOG(2, "exec: %s\n", s);
             if (!cdcommand(w, d, s)) /* send it back */
                 winwriteevent(w, e);
             if (na)
@@ -295,9 +295,9 @@ void acmeevent(Drive *d, Window *w, Event *e) {
                 winread(w, eq->q0, eq->q1, buf);
                 s = buf;
             }
-            DPRINT(2, "load %s\n", s);
+            LOG(2, "load %s\n", s);
             if ((n = atoi(s)) != 0) {
-                DPRINT(2, "mark %d\n", n);
+                LOG(2, "mark %d\n", n);
                 q0 = q1 = 0;
                 unmarkplay(w, NULL, 0, &q0, &q1, NULL);
 
@@ -307,7 +307,7 @@ void acmeevent(Drive *d, Window *w, Event *e) {
                     eq->q1 -= (q1 - q0);
                 }
                 if (!markplay(w, eq->q0))
-                    DPRINT(2, "err: %r\n");
+                    LOG(2, "err: %r\n");
 
                 playtrack(d, n - 1, n - 1);
             } else

--- a/acme/bin/source/acd/cddb.c
+++ b/acme/bin/source/acd/cddb.c
@@ -81,21 +81,21 @@ static int cddbfilltoc(Toc *t) {
         goto died;
 
     fprint(fd, "cddb query %8.8lux %d", diskid(t), t->ntrack);
-    DPRINT(2, "cddb query %8.8lux %d", diskid(t), t->ntrack);
+    LOG(2, "cddb query %8.8lux %d", diskid(t), t->ntrack);
     for (i = 0; i < t->ntrack; i++) {
         m = &t->track[i].start;
         fprint(fd, " %d", (m->m * 60 + m->s) * 75 + m->f);
-        DPRINT(2, " %d", (m->m * 60 + m->s) * 75 + m->f);
+        LOG(2, " %d", (m->m * 60 + m->s) * 75 + m->f);
     }
     m = &t->track[t->ntrack - 1].end;
     fprint(fd, " %d\r\n", m->m * 60 + m->s);
-    DPRINT(2, " %d\r\n", m->m * 60 + m->s);
+    LOG(2, " %d\r\n", m->m * 60 + m->s);
 
     if ((p = Brdline(&bin, '\n')) == NULL || atoi(p) / 100 != 2)
         goto died;
     p[Blinelen(&bin) - 1] = 0;
-    DPRINT(2, "cddb: %s\n", p);
-    nf = tokenize(p, f, nelem(f));
+    LOG(2, "cddb: %s\n", p);
+    nf = tokenize(p, f, (int)(sizeof(f) / sizeof(f[0])));
     if (nf < 1)
         goto died;
 
@@ -114,7 +114,7 @@ static int cddbfilltoc(Toc *t) {
         p[Blinelen(&bin) - 1] = '\0';
 
         /* accept first match */
-        nf = tokenize(p, f, nelem(f));
+        nf = tokenize(p, f, (int)(sizeof(f) / sizeof(f[0])));
         if (nf < 2)
             goto died;
         categ = f[0];
@@ -125,7 +125,7 @@ static int cddbfilltoc(Toc *t) {
             if ((p = Brdline(&bin, '\n')) == NULL)
                 goto died;
             p[Blinelen(&bin) - 1] = '\0';
-            DPRINT(2, "cddb: %s\n", p);
+            LOG(2, "cddb: %s\n", p);
         }
         break;
     case 202: /* no match */
@@ -144,7 +144,7 @@ static int cddbfilltoc(Toc *t) {
         q = p + Blinelen(&bin) - 1;
         while (isspace(*q))
             *q-- = 0;
-        DPRINT(2, "cddb %s\n", p);
+        LOG(2, "cddb %s\n", p);
         if (strncmp(p, "DTITLE=", 7) == 0) {
             if (gottitle)
                 append(&t->title, p + 7);

--- a/acme/bin/source/acd/main.c
+++ b/acme/bin/source/acd/main.c
@@ -46,22 +46,22 @@ void eventwatcher(Drive *d) {
     for (;;) {
         switch (alt(alts)) {
         case STATUS:
-            // DPRINT(2, "s...");
+            // LOG(2, "s...");
             d->status = s;
             if (s.state == Scompleted) {
                 s.state = Sunknown;
                 advancetrack(d, w);
             }
-            // DPRINT(2, "status %d %d %d %M %M\n", s.state, s.track, s.index, s.abs, s.rel);
+            // LOG(2, "status %d %d %d %M %M\n", s.state, s.track, s.index, s.abs, s.rel);
             sprint(buf, "%d:%2.2d", s.rel.m, s.rel.s);
             setplaytime(w, buf);
             break;
         case WEVENT:
-            // DPRINT(2, "w...");
+            // LOG(2, "w...");
             acmeevent(d, w, e);
             break;
         case TOCDISP:
-            // DPRINT(2,"td...");
+            // LOG(2,"td...");
             freetoc(&d->toc);
             d->toc = nt;
             drawtoc(w, d, &d->toc);
@@ -69,11 +69,11 @@ void eventwatcher(Drive *d) {
             alts[DBREQ].op = CHANSND;
             break;
         case DBREQ: /* sent */
-            // DPRINT(2,"dreq...");
+            // LOG(2,"dreq...");
             alts[DBREQ].op = CHANNOP;
             break;
         case DBREPLY:
-            // DPRINT(2,"drep...");
+            // LOG(2,"drep...");
             freetoc(&d->toc);
             d->toc = nt;
             redrawtoc(w, &d->toc);

--- a/acme/bin/source/acd/mmc.c
+++ b/acme/bin/source/acd/mmc.c
@@ -142,7 +142,7 @@ Again:
     if (t->ntrack > MTRACK)
         t->ntrack = MTRACK;
 
-    DPRINT(2, "%d %d\n", resp[3], resp[2]);
+    LOG(2, "%d %d\n", resp[3], resp[2]);
     t->ntrack = resp[3] - resp[2] + 1;
     t->track0 = resp[2];
 
@@ -252,21 +252,21 @@ void cdstatusproc(void *v) {
 
     threadsetname("cdstatusproc");
     d = v;
-    DPRINT(2, "cdstatus %d\n", getpid());
+    LOG(2, "cdstatus %d\n", getpid());
     for (;;) {
         ping(d);
-        // DPRINT(2, "d %d %d t %d %d\n", d->scsi->changetime, d->scsi->nchange, t.changetime,
+        // LOG(2, "d %d %d t %d %d\n", d->scsi->changetime, d->scsi->nchange, t.changetime,
         // t.nchange);
         if (playstatus(d, &s) == 0)
             send(d->cstatus, &s);
         if (d->scsi->changetime != t.changetime || d->scsi->nchange != t.nchange) {
             if (gettoc(d->scsi, &t) == 0) {
-                DPRINT(2, "sendtoc...\n");
+                LOG(2, "sendtoc...\n");
                 if (debug)
                     dumptoc(&t);
                 send(d->ctocdisp, &t);
             } else
-                DPRINT(2, "error: %r\n");
+                LOG(2, "error: %r\n");
         }
         sleep(1000);
     }

--- a/acme/bin/source/acd/toc.c
+++ b/acme/bin/source/acd/toc.c
@@ -8,11 +8,11 @@ void tocthread(void *v) {
 
     threadsetname("tocthread");
     d = v;
-    DPRINT(2, "recv ctocdisp?...");
+    LOG(2, "recv ctocdisp?...");
     while (recv(d->ctocdisp, &thetoc) == 1) {
-        DPRINT(2, "recv ctocdisp!...");
+        LOG(2, "recv ctocdisp!...");
         drawtoc(d->w, &thetoc);
-        DPRINT(2, "send dbreq...\n");
+        LOG(2, "send dbreq...\n");
         send(d->ctocdbreq, &thetoc);
     }
 }


### PR DESCRIPTION
## Summary
- clean up type alias formatting in `u.h`
- introduce debug-level `LOG` macro in `acd.h`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a09bf4c7c8331bace75bb6feccfe5