### PR TITLE
Update acd to use standard I/O

### DIFF
--- a/acme/bin/source/acd/acd.h
+++ b/acme/bin/source/acd/acd.h
@@ -12,7 +12,6 @@
 #include <stdio.h>
 
 /* Forward declarations for Plan9 types that the old code relied on. */
-typedef struct Biobuf Biobuf;
 typedef struct Channel Channel;
 typedef struct Scsi Scsi;
 
@@ -51,7 +50,7 @@ struct Window {
     int event;
     int addr;
     int data;
-    Biobuf *body;
+    FILE *body; /* buffered body file */
 
     /* event input */
     char buf[512];
@@ -165,7 +164,7 @@ extern int debug;
 
 #define DPRINT                                                                                     \
     if (debug)                                                                                     \
-    fprint
+        fprintf(stderr,
 void acmeevent(Drive *, Window *, Event *);
 
 int playtrack(Drive *, int, int);

--- a/acme/bin/source/acd/acme.c
+++ b/acme/bin/source/acd/acme.c
@@ -61,7 +61,7 @@ int setplaytime(Window *w, char *new) {
         return 0;
 
     q1--; /* > */
-    sprint(buf, "#%lud,#%lud", q0, q1);
+    snprintf(buf, sizeof(buf), "#%lud,#%lud", q0, q1);
     DPRINT(2, "setaddr %s\n", buf);
     if (!winsetaddr(w, buf, 1))
         return 0;
@@ -109,7 +109,7 @@ int markplay(Window *w, ulong q0) {
     if (w->data < 0)
         w->data = winopenfile(w, "data");
 
-    sprint(buf, "#%lud", q0);
+    snprintf(buf, sizeof(buf), "#%lud", q0);
     DPRINT(2, "addr %s\n", buf);
     if (!winsetaddr(w, buf, 1) || !winsetaddr(w, "-0", 1))
         return 0;
@@ -161,14 +161,31 @@ void drawtoc(Window *w, Drive *d, Toc *t) {
     if (!winsetaddr(w, ",", 1))
         return;
 
-    fprint(w->data, "Title\n\n");
+    {
+        FILE *fp = fdopen(dup(w->data), "w");
+        if (fp) {
+            fprintf(fp, "Title\n\n");
+            fclose(fp);
+        }
+    }
     playing = -1;
     if (d->status.state == Splaying || d->status.state == Spaused)
         playing = d->status.track - t->track0;
 
-    for (i = 0; i < t->ntrack; i++)
-        fprint(w->data, "%s%d/ Track %d\n", i == playing ? "> " : "", i + 1, i + 1);
-    fprint(w->data, "");
+    for (i = 0; i < t->ntrack; i++) {
+        FILE *fp = fdopen(dup(w->data), "w");
+        if (fp) {
+            fprintf(fp, "%s%d/ Track %d\n", i == playing ? "> " : "", i + 1, i + 1);
+            fclose(fp);
+        }
+    }
+    {
+        FILE *fp = fdopen(dup(w->data), "w");
+        if (fp) {
+            fprintf(fp, "");
+            fclose(fp);
+        }
+    }
 }
 
 void redrawtoc(Window *w, Toc *t) {
@@ -183,7 +200,7 @@ void redrawtoc(Window *w, Toc *t) {
     }
     for (i = 0; i < t->ntrack; i++) {
         if (t->track[i].title) {
-            sprint(old, "/Track %d", i + 1);
+            snprintf(old, sizeof(old), "/Track %d", i + 1);
             if (winsetaddr(w, old, 1))
                 write(w->data, t->track[i].title, strlen(t->track[i].title));
         }
@@ -235,7 +252,7 @@ void acmeevent(Drive *d, Window *w, Event *e) {
     switch (e->c1) { /* origin of action */
     default:
     Unknown:
-        fprint(2, "unknown message %c%c\n", e->c1, e->c2);
+        fprintf(stderr, "unknown message %c%c\n", e->c1, e->c2);
         break;
 
     case 'E': /* write to body or tag; can't affect us */
@@ -269,7 +286,7 @@ void acmeevent(Drive *d, Window *w, Event *e) {
             /* append chorded arguments */
             if (na) {
                 t = emalloc(strlen(s) + 1 + na + 1);
-                sprint(t, "%s %s", s, ea->b);
+                snprintf(t, strlen(s) + 1 + na + 1, "%s %s", s, ea->b);
                 s = t;
             }
             /* if it's a known command, do it */

--- a/acme/bin/source/acd/main.c
+++ b/acme/bin/source/acd/main.c
@@ -4,7 +4,7 @@
 int debug;
 
 void usage(void) {
-    fprint(2, "usage: acd dev\n");
+    fprintf(stderr, "usage: acd dev\n");
     threadexitsall("usage");
 }
 
@@ -53,7 +53,7 @@ void eventwatcher(Drive *d) {
                 advancetrack(d, w);
             }
             // DPRINT(2, "status %d %d %d %M %M\n", s.state, s.track, s.index, s.abs, s.rel);
-            sprint(buf, "%d:%2.2d", s.rel.m, s.rel.s);
+            snprintf(buf, sizeof(buf), "%d:%2.2d", s.rel.m, s.rel.s);
             setplaytime(w, buf);
             break;
         case WEVENT:

--- a/acme/bin/source/acd/mmc.c
+++ b/acme/bin/source/acd/mmc.c
@@ -1,5 +1,7 @@
 #include "acd.h"
+#include <errno.h>
 #include <stdint.h>
+#include <stdio.h>
 
 int msfconv(Fmt *fp) {
     Msf m;
@@ -129,7 +131,7 @@ Again:
 
     if (s->changetime == 0) {
         t->ntrack = 0;
-        werrstr("no media");
+        fprintf(stderr, "no media\n");
         return -1;
     }
 
@@ -148,7 +150,7 @@ Again:
 
     n = ((resp[0] << 8) | resp[1]) + 2;
     if (n < 4 + 8 * (t->ntrack + 1)) {
-        werrstr("bad read0 %d %d", n, 4 + 8 * (t->ntrack + 1));
+        fprintf(stderr, "bad read0 %d %d: %s\n", n, 4 + 8 * (t->ntrack + 1), strerror(errno));
         return -1;
     }
 
@@ -166,13 +168,13 @@ Again:
         return -1;
 
     if (s->changetime != t->changetime || s->nchange != t->nchange) {
-        fprint(2, "disk changed underfoot; repeating\n");
+        fprintf(stderr, "disk changed underfoot; repeating\n");
         goto Again;
     }
 
     n = ((resp[0] << 8) | resp[1]) + 2;
     if (n < 4 + 8 * (t->ntrack + 1)) {
-        werrstr("bad read");
+        fprintf(stderr, "bad read: %s\n", strerror(errno));
         return -1;
     }
 
@@ -188,7 +190,7 @@ Again:
 static void dumptoc(Toc *t) {
     int i;
 
-    fprint(1, "%d tracks\n", t->ntrack);
+    fprintf(stdout, "%d tracks\n", t->ntrack);
     for (i = 0; i < t->ntrack; i++)
         print("%d. %M-%M (%lud-%lud)\n", i + 1, t->track[i].start, t->track[i].end,
               t->track[i].bstart, t->track[i].bend);

--- a/acme/bin/source/acd/util.c
+++ b/acme/bin/source/acd/util.c
@@ -54,7 +54,7 @@ void error(char *fmt, ...) {
     va_list arg;
     char buf[256];
 
-    fprint(2, "Mail: ");
+    fprintf(stderr, "Mail: ");
     va_start(arg, fmt);
     n = vsnprint(buf, sizeof buf, fmt, arg);
     va_end(arg);

--- a/acme/bin/source/acd/win.c
+++ b/acme/bin/source/acd/win.c
@@ -1,4 +1,5 @@
 #include "acd.h"
+#include <errno.h>
 #include <stdint.h>
 
 Window *newwindow(void) {
@@ -46,7 +47,7 @@ int winopenfile(Window *w, char *f) {
     char buf[64];
     int fd;
 
-    sprint(buf, "/mnt/wsys/%d/%s", w->id, f);
+    snprintf(buf, sizeof(buf), "/mnt/wsys/%d/%s", w->id, f);
     fd = open(buf, ORDWR | OCEXEC);
     if (fd < 0)
         error("can't open window file %s: %r", f);
@@ -69,15 +70,17 @@ void winname(Window *w, char *s) {
 void winopenbody(Window *w, int mode) {
     char buf[256];
 
-    sprint(buf, "/mnt/wsys/%d/body", w->id);
-    w->body = Bopen(buf, mode | OCEXEC);
+    /* open the body file using stdio for buffered access */
+    snprintf(buf, sizeof(buf), "/mnt/wsys/%d/body", w->id);
+    w->body = fopen(buf, mode == OREAD ? "r" : "w");
     if (w->body == NULL)
-        error("can't open window body file: %r");
+        error("can't open window body file: %s", strerror(errno));
 }
 
 void winclosebody(Window *w) {
     if (w->body != NULL) {
-        Bterm(w->body);
+        /* close and discard buffered body file */
+        fclose(w->body);
         w->body = NULL;
     }
 }
@@ -85,8 +88,9 @@ void winclosebody(Window *w) {
 void winwritebody(Window *w, char *s, int n) {
     if (w->body == NULL)
         winopenbody(w, OWRITE);
-    if (Bwrite(w->body, s, n) != n)
-        error("write error to window: %r");
+    /* write buffered body text */
+    if (fwrite(s, 1, n, w->body) != (size_t)n)
+        error("write error to window: %s", strerror(errno));
 }
 
 int wingetec(Window *w) {
@@ -153,7 +157,12 @@ void wingetevent(Window *w, Event *e) {
 }
 
 void winwriteevent(Window *w, Event *e) {
-    fprint(w->event, "%c%c%d %d\n", e->c1, e->c2, e->q0, e->q1);
+    /* send event using stdio wrappers */
+    FILE *fp = fdopen(dup(w->event), "w");
+    if (fp) {
+        fprintf(fp, "%c%c%d %d\n", e->c1, e->c2, e->q0, e->q1);
+        fclose(fp);
+    }
 }
 
 static int nrunes(char *s, int nb) {
@@ -176,7 +185,7 @@ void winread(Window *w, uint q0, uint q1, char *data) {
         w->data = winopenfile(w, "data");
     m = q0;
     while (m < q1) {
-        n = sprint(buf, "#%d", m);
+        n = snprintf(buf, sizeof(buf), "#%d", m);
         if (write(w->addr, buf, n) != n)
             error("error writing addr: %r");
         n = read(w->data, buf, sizeof buf);
@@ -204,7 +213,8 @@ void windormant(Window *w) {
         w->addr = -1;
     }
     if (w->body != NULL) {
-        Bterm(w->body);
+        /* close buffered body handle */
+        fclose(w->body);
         w->body = NULL;
     }
     if (w->data >= 0) {
@@ -229,7 +239,8 @@ int windel(Window *w, int sure) {
 
 void winclean(Window *w) {
     if (w->body)
-        Bflush(w->body);
+        /* flush buffered writes */
+        fflush(w->body);
     ctlprint(w->ctl, "clean\n");
 }
 
@@ -269,7 +280,8 @@ char *winreadbody(Window *w,
             na += 1024;
             s = realloc(s, na + 1);
         }
-        m = Bread(w->body, s + n, na - n);
+        /* read from buffered body */
+        m = fread(s + n, 1, na - n, w->body);
         if (m <= 0)
             break;
         n += m;


### PR DESCRIPTION
## Summary
- migrate `Biobuf` uses to standard `FILE` functions
- replace plan9 `fprint`/`sprint` with `fprintf`/`snprintf`
- drop `Bopen/Bterm/Bread/Bwrite/Bflush` for stdio
- use `perror`/`strerror` in place of `werrstr`

## Testing
- `clang-format -i acme/bin/source/acd/acd.h acme/bin/source/acd/acme.c acme/bin/source/acd/cddb.c acme/bin/source/acd/main.c acme/bin/source/acd/mmc.c acme/bin/source/acd/util.c acme/bin/source/acd/win.c`
- `pre-commit` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a09b1f1a08331948a0ecaeeeedfde