### PR TITLE
Migrate acd to C11 threads

### DIFF
--- a/acme/bin/source/acd/acd.h
+++ b/acme/bin/source/acd/acd.h
@@ -10,11 +10,51 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <threads.h>
 
 /* Forward declarations for Plan9 types that the old code relied on. */
 typedef struct Biobuf Biobuf;
 typedef struct Channel Channel;
 typedef struct Scsi Scsi;
+
+/*
+ * A lightweight approximation of the Plan 9 `Channel`.  Messages are
+ * copied into an internal queue protected by a mutex.  When
+ * `capacity` is zero the channel behaves synchronously: a sender will
+ * block until a receiver consumes the message.
+ */
+struct Channel {
+    mtx_t lock;    /* protects all fields below */
+    cnd_t send_cv; /* wait here when no space is available */
+    cnd_t recv_cv; /* wait here when no data is available */
+
+    unsigned char *data; /* circular queue storage */
+    size_t esize;        /* size of each message */
+    int capacity;        /* number of queued messages; 0 => synchronous */
+    int count;           /* current number of messages */
+    int rpos;            /* read position in `data` */
+    int wpos;            /* write position in `data` */
+    int waiting_recv;    /* receivers waiting in synchronous mode */
+};
+
+typedef struct Alt Alt;
+struct Alt {
+    Channel *c; /* channel to operate on */
+    void *v;    /* buffer for send/recv */
+    int op;     /* CHANSND, CHANRCV, ... */
+};
+
+enum { CHANSND, CHANRCV, CHANNOP, CHANEND };
+
+Alt mkalt(Channel *, void *, int);
+int alt(Alt *);
+Channel *chancreate(size_t, int);
+int send(Channel *, void *);
+int recv(Channel *, void *);
+int sendp(Channel *, void *);
+void *recvp(Channel *);
+int chan_try_send(Channel *, void *);
+int chan_try_recv(Channel *, void *);
 
 /* Simple stand-ins for historical Plan9 types. */
 typedef unsigned long ulong;
@@ -74,7 +114,7 @@ extern void winwriteevent(Window *, Event *);
 extern void winread(Window *, uint, uint, char *);
 extern int windel(Window *, int);
 extern void wingetevent(Window *, Event *);
-extern void wineventproc(void *);
+extern int wineventproc(void *);
 extern void winwritebody(Window *, char *, int);
 extern void winclean(Window *);
 extern int winselect(Window *, char *, int);
@@ -157,9 +197,9 @@ struct Drive {
 int gettoc(Scsi *, Toc *);
 void drawtoc(Window *, Drive *, Toc *);
 void redrawtoc(Window *, Toc *);
-void tocproc(void *);      /* Drive* */
-void cddbproc(void *);     /* Drive* */
-void cdstatusproc(void *); /* Drive* */
+int tocproc(void *);      /* Drive* */
+int cddbproc(void *);     /* Drive* */
+int cdstatusproc(void *); /* Drive* */
 
 extern int debug;
 

--- a/acme/bin/source/acd/acme.c
+++ b/acme/bin/source/acd/acme.c
@@ -1,5 +1,6 @@
 #include "acd.h"
 #include <stdint.h>
+#include <stdlib.h>
 
 static int iscmd(char *s, char *cmd) {
     int len;
@@ -124,7 +125,7 @@ int cdcommand(Window *w, Drive *d, char *s) {
 
     if (iscmd(s, "Del")) {
         if (windel(w, 0))
-            threadexitsall(NULL);
+            exit(0);
         return 1;
     }
     if (iscmd(s, "Stop")) {

--- a/acme/bin/source/acd/cddb.c
+++ b/acme/bin/source/acd/cddb.c
@@ -176,13 +176,13 @@ static int cddbfilltoc(Toc *t) {
     return 0;
 }
 
-void cddbproc(void *v) {
+int cddbproc(void *v) {
     Drive *d;
     Toc t;
 
-    threadsetname("cddbproc");
     d = v;
     while (recv(d->cdbreq, &t))
         if (cddbfilltoc(&t) == 0)
             send(d->cdbreply, &t);
+    return 0;
 }

--- a/acme/bin/source/acd/mmc.c
+++ b/acme/bin/source/acd/mmc.c
@@ -242,7 +242,7 @@ static int playstatus(Drive *d, Cdstatus *stat) {
     return 0;
 }
 
-void cdstatusproc(void *v) {
+int cdstatusproc(void *v) {
     Drive *d;
     Toc t;
     Cdstatus s;
@@ -250,7 +250,6 @@ void cdstatusproc(void *v) {
     t.changetime = ~0;
     t.nchange = ~0;
 
-    threadsetname("cdstatusproc");
     d = v;
     DPRINT(2, "cdstatus %d\n", getpid());
     for (;;) {
@@ -270,4 +269,5 @@ void cdstatusproc(void *v) {
         }
         sleep(1000);
     }
+    return 0;
 }

--- a/acme/bin/source/acd/toc.c
+++ b/acme/bin/source/acd/toc.c
@@ -3,10 +3,9 @@
 
 Toc thetoc;
 
-void tocthread(void *v) {
+int tocthread(void *v) {
     Drive *d;
 
-    threadsetname("tocthread");
     d = v;
     DPRINT(2, "recv ctocdisp?...");
     while (recv(d->ctocdisp, &thetoc) == 1) {
@@ -15,6 +14,7 @@ void tocthread(void *v) {
         DPRINT(2, "send dbreq...\n");
         send(d->ctocdbreq, &thetoc);
     }
+    return 0;
 }
 
 void freetoc(Toc *t) {
@@ -25,11 +25,10 @@ void freetoc(Toc *t) {
         free(t->track[i].title);
 }
 
-void cddbthread(void *v) {
+int cddbthread(void *v) {
     Drive *d;
     Toc t;
 
-    threadsetname("cddbthread");
     d = v;
     while (recv(d->ctocdbreply, &t) == 1) {
         if (thetoc.nchange == t.nchange) {
@@ -38,9 +37,10 @@ void cddbthread(void *v) {
             redrawtoc(d->w, &thetoc);
         }
     }
+    return 0;
 }
 
-void cdstatusthread(void *v) {
+int cdstatusthread(void *v) {
     Drive *d;
     Cdstatus s;
 
@@ -48,4 +48,5 @@ void cdstatusthread(void *v) {
 
     for (;;)
         recv(d->cstat, &s);
+    return 0;
 }

--- a/acme/bin/source/acd/util.c
+++ b/acme/bin/source/acd/util.c
@@ -1,5 +1,6 @@
 #include "acd.h"
 #include <stdint.h>
+#include <stdlib.h>
 
 void *emalloc(uint n) {
     void *p;
@@ -60,7 +61,7 @@ void error(char *fmt, ...) {
     va_end(arg);
     write(2, buf, n);
     write(2, "\n", 1);
-    threadexitsall(fmt);
+    exit(1);
 }
 
 void ctlprint(int fd, char *fmt, ...) {
@@ -73,4 +74,155 @@ void ctlprint(int fd, char *fmt, ...) {
     va_end(arg);
     if (write(fd, buf, n) != n)
         error("control file write error: %r");
+}
+
+/*
+ * Channel primitives ---------------------------------------------------------
+ */
+
+/*
+ * Allocate a new channel capable of storing up to `buffered` messages of
+ * `size` bytes. When `buffered` is zero the channel acts synchronously:
+ * senders wait for receivers to accept the value.
+ */
+Channel *chancreate(size_t size, int buffered) {
+    Channel *c = emalloc(sizeof(Channel));
+
+    mtx_init(&c->lock, mtx_plain);
+    cnd_init(&c->send_cv);
+    cnd_init(&c->recv_cv);
+
+    c->esize = size;
+    c->capacity = buffered;
+    if (c->capacity == 0)
+        c->capacity = 1; /* storage for rendezvous */
+    c->data = emalloc(c->esize * c->capacity);
+
+    c->count = 0;
+    c->rpos = 0;
+    c->wpos = 0;
+    c->waiting_recv = 0;
+
+    return c;
+}
+
+/* internal helper implementing blocking/non-blocking send */
+static int chan_send_common(Channel *c, void *v, int block) {
+    mtx_lock(&c->lock);
+
+    while (c->capacity == 1 && c->waiting_recv == 0)
+        cnd_wait(&c->send_cv, &c->lock);
+
+    while (c->capacity > 0 && c->count == c->capacity) {
+        if (!block) {
+            mtx_unlock(&c->lock);
+            return 0;
+        }
+        cnd_wait(&c->send_cv, &c->lock);
+    }
+
+    memcpy(c->data + c->wpos * c->esize, v, c->esize);
+    c->wpos = (c->wpos + 1) % c->capacity;
+    c->count++;
+    cnd_signal(&c->recv_cv);
+
+    if (c->capacity == 1) {
+        while (c->count == 1 && block)
+            cnd_wait(&c->send_cv, &c->lock);
+        if (c->count == 1 && !block) {
+            mtx_unlock(&c->lock);
+            return 0;
+        }
+    }
+
+    mtx_unlock(&c->lock);
+    return 1;
+}
+
+/* internal helper implementing blocking/non-blocking receive */
+static int chan_recv_common(Channel *c, void *v, int block) {
+    mtx_lock(&c->lock);
+
+    c->waiting_recv++;
+    cnd_signal(&c->send_cv);
+
+    while (c->count == 0) {
+        if (!block) {
+            c->waiting_recv--;
+            mtx_unlock(&c->lock);
+            return 0;
+        }
+        cnd_wait(&c->recv_cv, &c->lock);
+    }
+
+    memcpy(v, c->data + c->rpos * c->esize, c->esize);
+    c->rpos = (c->rpos + 1) % c->capacity;
+    c->count--;
+    c->waiting_recv--;
+    cnd_signal(&c->send_cv);
+
+    mtx_unlock(&c->lock);
+    return 1;
+}
+
+int send(Channel *c, void *v) {
+    return chan_send_common(c, v, 1);
+}
+int recv(Channel *c, void *v) {
+    return chan_recv_common(c, v, 1);
+}
+int chan_try_send(Channel *c, void *v) {
+    return chan_send_common(c, v, 0);
+}
+int chan_try_recv(Channel *c, void *v) {
+    return chan_recv_common(c, v, 0);
+}
+
+int sendp(Channel *c, void *v) {
+    return send(c, &v);
+}
+
+void *recvp(Channel *c) {
+    void *v = NULL;
+    recv(c, &v);
+    return v;
+}
+
+Alt mkalt(Channel *c, void *v, int op) {
+    Alt a = {c, v, op};
+    return a;
+}
+
+/*
+ * Simple alt implementation that repeatedly attempts the operations
+ * without blocking until one succeeds.  This is sufficient for the
+ * narrow use within eventwatcher.
+ */
+int alt(Alt *a) {
+    /* count choices */
+    int n = 0;
+    while (a[n].op != CHANEND)
+        n++;
+
+    for (;;) {
+        int start = rand() % n;
+        for (int off = 0; off < n; off++) {
+            int i = (start + off) % n;
+            switch (a[i].op) {
+            case CHANSND:
+                if (chan_try_send(a[i].c, a[i].v)) {
+                    a[i].op = CHANNOP;
+                    return i;
+                }
+                break;
+            case CHANRCV:
+                if (chan_try_recv(a[i].c, a[i].v))
+                    return i;
+                break;
+            default:
+                break;
+            }
+        }
+        thrd_yield();
+    }
 }

--- a/acme/bin/source/acd/win.c
+++ b/acme/bin/source/acd/win.c
@@ -28,11 +28,10 @@ void winsetdump(Window *w, char *dir, char *cmd) {
         ctlprint(w->ctl, "dump %s\n", cmd);
 }
 
-void wineventproc(void *v) {
+int wineventproc(void *v) {
     Window *w;
     int i;
 
-    threadsetname("wineventproc");
     w = v;
     for (i = 0;; i++) {
         if (i >= NEVENT)
@@ -40,6 +39,7 @@ void wineventproc(void *v) {
         wingetevent(w, &w->e[i]);
         sendp(w->cevent, &w->e[i]);
     }
+    return 0;
 }
 
 int winopenfile(Window *w, char *f) {
@@ -95,7 +95,7 @@ int wingetec(Window *w) {
         if (w->nbuf <= 0) {
             /* probably because window has exited, and only called by wineventproc, so just shut
              * down */
-            threadexits(NULL);
+            thrd_exit(NULL);
         }
         w->bufp = w->buf;
     }


### PR DESCRIPTION
## Summary
- replace Plan9 style channels with C11 `<threads.h>` primitives
- update util.c with channel and alt implementations
- remove Plan9 thread functions and switch to standard threads
- make `main` standard C entry point
- improved channel model with proper rendezvous and buffering

## Testing
- `clang-format -i acme/bin/source/acd/acd.h acme/bin/source/acd/main.c acme/bin/source/acd/util.c`
- ❌ `pre-commit run --files acme/bin/source/acd/acd.h acme/bin/source/acd/main.c acme/bin/source/acd/util.c` *(failed: `pre-commit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a09a62c0c833193397d76b2412288