### PR TITLE
Fix typedefs and update logging

### DIFF
--- a/386/include/u.h
+++ b/386/include/u.h
@@ -6,27 +6,29 @@
 
 /* Basic type aliases using modern C17 fixed-width types. */
 #define nil ((void *)0)
-typedef uint16_t ushort;     /* 16-bit unsigned integer */
-typedef uint8_t uchar;       /* 8-bit unsigned integer */
-typedef unsigned long ulong; /* native unsigned long */
-typedef uint32_t uint;       /* 32-bit unsigned integer */
-typedef int8_t schar;        /* 8-bit signed integer */
-typedef int64_t vlong;       /* 64-bit signed integer */
-typedef uint64_t uvlong;     /* 64-bit unsigned integer */
-typedef uintptr_t uintptr;   /* unsigned integer the size of a pointer */
-typedef size_t usize;        /* alias for size_t */
-typedef uint32_t Rune;       /* Unicode code point */
+typedef uint16_t ushort; /* 16-bit unsigned integer */
+typedef uint8_t uchar;   /* 8-bit unsigned integer */
+/* 32-bit unsigned long explicitly typed using <stdint.h>. */
+typedef uint32_t ulong;
+typedef uint32_t uint;     /* 32-bit unsigned integer */
+typedef int8_t schar;      /* 8-bit signed integer */
+typedef int64_t vlong;     /* 64-bit signed integer */
+typedef uint64_t uvlong;   /* 64-bit unsigned integer */
+typedef uintptr_t uintptr; /* unsigned integer the size of a pointer */
+typedef size_t usize;      /* alias for size_t */
+typedef uint32_t Rune;     /* Unicode code point */
 
 typedef union FPdbleword FPdbleword;
 typedef long jmp_buf[2];
 #define JMPBUFSP 0
 #define JMPBUFPC 1
 #define JMPBUFDPC 0
-typedef unsigned int mpdigit; /* for /sys/include/mp.h */
-typedef uint8_t u8int;        /* 8-bit unsigned integer */
-typedef uint16_t u16int;      /* 16-bit unsigned integer */
-typedef uint32_t u32int;      /* 32-bit unsigned integer */
-typedef uint64_t u64int;      /* 64-bit unsigned integer */
+/* Multiprecision digit used by <mp.h>. */
+typedef uint32_t mpdigit;
+typedef uint8_t u8int;   /* 8-bit unsigned integer */
+typedef uint16_t u16int; /* 16-bit unsigned integer */
+typedef uint32_t u32int; /* 32-bit unsigned integer */
+typedef uint64_t u64int; /* 64-bit unsigned integer */
 
 /* FCR */
 #define FPINEX (1 << 5)

--- a/acme/bin/source/acd/acd.h
+++ b/acme/bin/source/acd/acd.h
@@ -54,15 +54,9 @@ void *recvp(Channel *);
 int chan_try_send(Channel *, void *);
 int chan_try_recv(Channel *, void *);
 
-/* Simple stand-ins for historical Plan9 types. */
-typedef unsigned long ulong;
-typedef uint32_t uint;
-/* Simple stand-ins for historical Plan9 types.
- * These aliases mirror the common Plan 9 names while
- * using explicit C99 fixed-width types for clarity.
- */
-typedef unsigned long ulong; /* native unsigned long */
-typedef uint32_t uint;       /* 32-bit unsigned integer */
+/* Plan 9 type aliases using explicit C17 integer sizes. */
+typedef uint32_t ulong; /* 32-bit unsigned long */
+typedef uint32_t uint;  /* 32-bit unsigned integer */
 
 /* acme */
 typedef struct Fmt Fmt; /* Formatting context placeholder */
@@ -208,15 +202,13 @@ int cdstatusproc(void *); /* Drive* */
 /* Global debug level controlling verbosity of diagnostic output. */
 extern int debug;
 
-#define DPRINT                                                                                     \
-    if (debug)                                                                                     \
-        fprintf(stderr,
 /* Debug logging helper with a verbosity level. */
 #define LOG(level, ...)                                                                            \
     do {                                                                                           \
         if (debug >= (level))                                                                      \
             fprintf(stderr, __VA_ARGS__);                                                          \
     } while (0)
+
 void acmeevent(Drive *, Window *, Event *);
 
 int playtrack(Drive *, int, int);

--- a/acme/bin/source/acd/acme.c
+++ b/acme/bin/source/acd/acme.c
@@ -63,7 +63,7 @@ int setplaytime(Window *w, char *new) {
 
     q1--; /* > */
     snprintf(buf, sizeof(buf), "#%lud,#%lud", q0, q1);
-    DPRINT(2, "setaddr %s\n", buf);
+    LOG(2, "setaddr %s\n", buf);
     if (!winsetaddr(w, buf, 1))
         return 0;
 
@@ -111,7 +111,7 @@ int markplay(Window *w, ulong q0) {
         w->data = winopenfile(w, "data");
 
     snprintf(buf, sizeof(buf), "#%lud", q0);
-    DPRINT(2, "addr %s\n", buf);
+    LOG(2, "addr %s\n", buf);
     sprint(buf, "#%lud", q0);
     LOG(2, "addr %s\n", buf);
     if (!winsetaddr(w, buf, 1) || !winsetaddr(w, "-0", 1))


### PR DESCRIPTION
## Summary
- use explicit `<stdint.h>` typedefs in `u.h`
- use standard integer aliases in `acd.h`
- replace `DPRINT` with `LOG` macro
- convert `nelem` to `sizeof/sizeof`
- switch debug prints to `LOG`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_683a1ca42bfc8331b5589727d969a76a