### PR TITLE
Refine msf helper and outline C17 roadmap

### DIFF
--- a/docs/c17-roadmap.md
+++ b/docs/c17-roadmap.md
@@ -1,0 +1,25 @@
+# C17 Migration Roadmap
+
+This document outlines a staged approach for converting the Harvey `acd` sources from their original K&R/Plan9 style C into strict C17. The repository currently contains eight C source files in `acme/bin/source/acd`.
+
+## 1. Initial Survey
+
+Run `scripts/analyze_repo.py` to detect Plan9 constructs. The current output identifies uses of `Channel`, `dial()` and custom formatting functions such as `fmtprint`.
+
+## 2. Batch Refactoring
+
+Refactor the code in batches of up to 30 files. For each batch:
+
+1. Replace Plan9 headers with standard equivalents.
+2. Translate Plan9 concurrency primitives to POSIX threads.
+3. Remove K&R declarations and adopt modern prototypes.
+4. Apply `clang-format` to enforce the style defined in `.clang-format`.
+5. Compile with `-std=c17` and resolve warnings.
+
+## 3. Validation
+
+Use `pre-commit` hooks to run `clang-format`, `clang-tidy` and compile the updated sources. Continuous integration should ensure no regressions as the migration progresses.
+
+## 4. Tracking Progress
+
+Record remaining Plan9 constructs in `docs/acd-plan9-audit.md` and update it after each batch is refactored. The modernization is considered complete when the scan reports zero Plan9 patterns and the code builds cleanly with C17.

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -8,6 +8,7 @@ This document outlines the high level tasks required to refactor the Harvey util
 - Use `scripts/analyze_repo.py` to track remaining Plan9 constructs in the `acd` sources.
 - Introduce a portable build system using clang with `-std=c17`.
 - Enable compiler warnings for portability issues and adopt clang-tidy modernize checks.
+- See `c17-roadmap.md` for a detailed staged approach.
 
 ## C++17 Components
 

--- a/modern/acd.c
+++ b/modern/acd.c
@@ -12,7 +12,7 @@
  */
 int main(int argc, char **argv) {
     CmdArgs args = parse_args((int32_t)argc, argv);
-    printf("C23 acd skeleton running on device %s. Verbose=%d\n", args.device, (int)args.verbose);
+    printf("C17 acd skeleton running on device %s. Verbose=%d\n", args.device, (int)args.verbose);
 
     /* Example use of the recursive spinlock. */
     Spinlock lock;

--- a/modern/msf.h
+++ b/modern/msf.h
@@ -29,3 +29,19 @@ static inline Msf msf_from_frames(uint32_t frames) {
     msf.f = (int32_t)(frames % MSF_FRAMES_PER_SEC);
     return msf;
 }
+
+/*
+ * Convert an Msf structure back to an absolute frame count. Useful when
+ * interacting with low level CD commands which operate on frame numbers.
+ */
+static inline uint32_t msf_to_frames(Msf msf) {
+    /* Convert minutes to frames. */
+    uint32_t from_minutes = (uint32_t)(msf.m * MSF_SECS_PER_MIN * MSF_FRAMES_PER_SEC);
+    /* Convert seconds to frames. */
+    uint32_t from_seconds = (uint32_t)(msf.s * MSF_FRAMES_PER_SEC);
+    /* Frames are already stored in the structure. */
+    uint32_t from_frames = (uint32_t)msf.f;
+
+    /* Sum all contributions for the total frame count. */
+    return from_minutes + from_seconds + from_frames;
+}


### PR DESCRIPTION
## Summary
- clarify `msf_to_frames` with intermediate variables and comments
- document a staged C17 migration strategy
- reference the new roadmap in the modernization plan

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a2429a2648331bffb13a5df041160