### PR TITLE
Update docs with final threading model

### DIFF
--- a/docs/acd-plan9-audit.md
+++ b/docs/acd-plan9-audit.md
@@ -33,3 +33,22 @@ work; it does not perfectly reproduce Plan 9 semantics.  A full port
 would replace the channel based concurrency with standard POSIX queues or
 other C23 facilities.
 
+## Final thread and I/O model
+
+After completing the modernization, the temporary Plan 9 compatibility
+wrapper was removed.  All concurrency now uses POSIX `pthread` calls
+directly and `modern/plan9_compat.h` no longer exists.  I/O routines were
+rewritten to rely solely on standard C and POSIX interfaces such as
+`open`, `read`, `write`, `fopen` and `fread`.  No Plan 9 headers remain in
+the build.
+
+Build the updated sources with any modern C toolchain:
+
+```bash
+cd modern
+make
+```
+
+The build system requires only clang or gcc and does not depend on any
+Plan 9 libraries or shims.
+

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -27,3 +27,22 @@ This document outlines the high level tasks required to refactor the Harvey util
 - Use `pre-commit` to run clang-format, clang-tidy and build checks.
 - Update the build scripts in `modern/` to handle both C and C++ sources.
 
+## Final thread and I/O approach
+
+The modern code base no longer relies on the Plan 9 threading model.  All
+concurrency uses POSIX `pthread` calls and the temporary
+`modern/plan9_compat.h` wrapper has been removed.  File operations and
+buffer management have been rewritten around standard C and POSIX
+functions.  The optional APEX layer may still be used for additional
+POSIX tooling but is not required for building `acd`.
+
+### Building
+
+Compile the utilities with a normal host compiler:
+
+```bash
+make -C modern
+```
+
+Only clang or gcc is needed; no Plan 9 libraries or cross toolchains are
+required.


### PR DESCRIPTION
## Summary
- update Plan9 audit notes with final pthread strategy
- describe modern I/O approach
- add build instructions with standard toolchain

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_683a7ce1296483318f2255e6a4d79f1c