### PR TITLE
Update docs and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ All code modifications must embrace modern programming paradigms and idiomatic e
 - Factor out shared logic so each function has a single responsibility.
 - Ensure all functions carry Doxygen comments documenting parameters, return values and side effects.
 - Adopt the most modern language features available for the file's language standard.
+- Decompose complex algorithms and re-synthesize them using modern idiomatic patterns grounded in mathematical principles.
 
 Additionally, keep code formatting clean and consistent. Use `clang-format` or
 equivalent tooling where applicable. Install the git hooks with

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ Use `make test` to compile all entries defined in the `ARCHS` variable
 
 ## Documentation
 
-Doxygen extracts API references for all C sources. Run `doxygen docs/Doxyfile` to
-generate XML output consumed by Sphinx. To build the HTML manual, execute:
+Run `doxygen docs/Doxyfile` to extract API references from all C sources.  The
+XML output is written to `build/docs/xml` and consumed by Sphinx.  Build the
+HTML manual with:
 
 ```bash
-sphinx-build -b html docs docs/_build
+sphinx-build -b html docs build/sphinx
 ```
 
 The resulting pages in `docs/_build` can be viewed with any browser.

--- a/modern/args.c
+++ b/modern/args.c
@@ -18,9 +18,8 @@ static void usage(void) {
  * The @c -v flag enables verbose output and the device name is taken from the
  * first positional argument.
  *
- * @param argc Argument count.
- * @param argv Argument vector.
- * @return Parsed arguments structure.
+ * This function consumes the traditional @p argc and @p argv parameters
+ * supplied to @c main and returns the parsed options structure.
  */
 CmdArgs parse_args(int32_t argc, char **argv) {
     CmdArgs args = {.verbose = false, .device = NULL};


### PR DESCRIPTION
## Summary
- expand contributor guidelines
- clarify doc build instructions
- update argument parser docs

## Testing
- `doxygen docs/Doxyfile`
- `sphinx-build -b html docs ../build/sphinx`
- `pre-commit run --files modern/args.c README.md AGENTS.md`

------
https://chatgpt.com/codex/tasks/task_e_68464f1dbbc48331b8d14d0347aec1fc